### PR TITLE
Corresponding to C99

### DIFF
--- a/04-macos-big-sur.patch
+++ b/04-macos-big-sur.patch
@@ -1,0 +1,54 @@
+--- a/src/macim.h	1970-01-01 09:00:00.000000000 +0900
++++ b/src/macim.h	2020-06-27 16:06:54.000000000 +0900
+@@ -0,0 +1,30 @@
++/* NeXT/Open/GNUstep / macOS communication module.      -*- coding: utf-8 -*-
++
++Copyright (C) 2020 Free Software Foundation, Inc.
++
++This file is part of GNU Emacs.
++
++GNU Emacs is free software: you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation, either version 3 of the License, or (at
++your option) any later version.
++
++GNU Emacs is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
++
++*/
++
++#ifndef macim_h
++#define macim_h
++
++void mac_init_input_method ();
++int mac_pass_key_to_system (int code, int modifiers);
++int mac_pass_key_directly_to_emacs ();
++int mac_store_change_input_method_event ();
++
++#endif /* macim_h */
+--- a/src/nsterm.m	2019-01-23 22:53:23.000000000 +0900
++++ b/src/nsterm.m	2020-06-27 17:05:13.000000000 +0900
+@@ -66,6 +66,7 @@ GNUstep port and post-20 update by Adria
+ 
+ #ifdef NS_IMPL_COCOA
+ #include "macfont.h"
++#include "macim.h"
+ #endif
+ 
+ static EmacsMenu *dockMenu;
+
+--- a/src/nsfns.m	2019-01-07 23:26:07.000000000 +0900
++++ b/src/nsfns.m	2020-06-27 17:01:54.000000000 +0900
+@@ -47,6 +47,7 @@ GNUstep port and post-20 update by Adria
+ #ifdef NS_IMPL_COCOA
+ #include <IOKit/graphics/IOGraphicsLib.h>
+ #include "macfont.h"
++#include "macim.h"
+ #endif
+ 
+ 

--- a/build.sh
+++ b/build.sh
@@ -114,6 +114,7 @@ build_emacs26() {
     patch -p1 -i ../../01-remove-blessmail.patch
     patch -p1 -i ../../02-provisional-emacs26.3-unexmacosx.c.patch
     patch -p1 -i ../../03-bump-emacs-version.patch
+    patch -p1 -i ../../04-macos-big-sur.patch
     patch -p1 -i ../ns-inline-patch/emacs-25.2-inline.patch
     
     ./autogen.sh


### PR DESCRIPTION
## Overview

Ref #4, this PR fixed it.
Caused errors at the following when building:

- nsterm.m:5442:7:
  - error: implicit declaration of function 'mac_store_change_input_method_event' is invalid in C99 [-Werror,-Wimplicit-function-declaration]   
if (mac_store_change_input_method_event())
- nsterm.m:6283:11:
  - error: implicit declaration of function 'mac_pass_key_directly_to_emacs' is invalid in C99 [-Werror,-Wimplicit-function-declaration]   
if (mac_pass_key_directly_to_emacs ()
- nsterm.m:6302:19:
  - error: implicit declaration of function 'mac_pass_key_to_system' is invalid in C99 [-Werror,-Wimplicit-function-declaration]   
|| !mac_pass_key_to_system (code, flags

Maybe [emacs-25.2-inline.patch](https://github.com/takaxp/ns-inline-patch/blob/master/emacs-25.2-inline.patch) has same issue.

## Build env

Type1

- macOS Big Sur Beta
- Xcode 12 Beta

Type2

- macOS Catalina
- Xcode 11