### PR TITLE
Add Swift migration analysis for Emacs 30.2 NS backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,32 @@ sh build.sh emacs26
 
 # Objective
 
-Immediate 
+Immediate
 
 - Get buildable on Bitrise CI
 - Get launchable on clean installed macOS
 - Get the Apple Notarization
+- **Keep Emacs current with modern macOS app lifecycle events**
 
 Finally
 
-- Porting Objective-C code to Swift
 - Support Xcode
 - Support iPadOS
 - Support Sandbox style macOS App
 - Distribute on Mac App Store
+
+Porting to Swift was investigated and **dropped**. Every AppKit lifecycle
+API is reachable from Objective-C, so the port would carry significant
+cost with no additional capability -- and would forfeit the ability to
+contribute changes back upstream. See [docs/swift-migration.md](./docs/swift-migration.md).
+
+# Documentation
+
+Start here if you are picking up this work:
+
+- [docs/roadmap.md](./docs/roadmap.md) -- **work instructions, start at Phase 0**
+- [docs/macos-lifecycle.md](./docs/macos-lifecycle.md) -- what Emacs 30.2 implements today and what it lacks
+- [docs/swift-migration.md](./docs/swift-migration.md) -- background research on why Swift was dropped
 
 # Dependency
 

--- a/docs/macos-lifecycle.md
+++ b/docs/macos-lifecycle.md
@@ -1,0 +1,230 @@
+# Emacs を最新 macOS のアプリライフサイクルに追従させる
+
+対象: GNU Emacs 30.2 (`emacs-30.2` タグ)
+
+## 結論を先に
+
+**Objective-C のまま進められる。Swift は不要。**
+
+- AppKit の API は Objective-C から 100% 利用できる。ライフサイクル系に
+  Swift 専用 API は一つもない。すべて通常の ObjC メソッド / 通知である。
+- Swift を挟むと `docs/swift-migration.md` に列挙したブロッカー
+  (`lisp.h` が import 不能、`DEFUN` が `globals.h` から消える、`longjmp` が
+  Swift フレームを飛び越える、GNUstep 放棄による恒久フォーク化) を
+  **すべて背負ったうえで、得られる機能は増えない**。
+- さらに重要な点として、ObjC で書けば **上流 GNU Emacs に還元できる**。
+  Swift では原理的に不可能 (GNU プロジェクトは実装言語として C 系以外を
+  受け付けない)。長期の追従コストが根本的に変わる。
+
+そして本題。**最新ライフサイクルへの追従を阻んでいるのは言語ではなく、
+Emacs のランループ構造である。** これは Swift 化しても 1 ミリも改善しない。
+
+---
+
+## 1. 本当の障害: Emacs は通常の AppKit ランループを回していない
+
+### 1.1 実際の構造
+
+- `NSApplicationMain` は使わない。`nsterm.m:5649` で `[EmacsApp sharedApplication]`
+  を呼ぶだけ。
+- イベント処理は Emacs 側が主導する。`ns_read_socket_1` (`nsterm.m:4743`) と
+  `ns_select_1` (`nsterm.m:4835`) が **`[NSApp run]` を短時間だけ回して抜ける**
+  という動作を繰り返す。
+- 抜ける手段は自分宛に `NX_APPDEFINED` イベントを投げること
+  (`ns_send_appdefined`, `nsterm.m:4663`)。これを `-[EmacsApp sendEvent:]`
+  (`nsterm.m:5988`, 説明コメントは `nsterm.m:6035`) が捕まえてループを止める。
+- `-[EmacsApp run]` のオーバーライド (`nsterm.m:5928`) は macOS 10.9 専用の
+  回避策で、現行 macOS では `[super run]` に素通しされる。
+
+### 1.2 何が起きるか
+
+**AppKit のデリゲートコールバックと NSWorkspace 通知は、Emacs が
+`[NSApp run]` の中にいる間しか配送されない。** つまり「入力待ちの間だけ」。
+
+Lisp を実行している間 (長い font-lock、GC、同期プロセス、`sleep-for`、
+Tramp のブロッキング I/O) は一切ポンプしないため、macOS からは
+**応答なしのアプリに見える**。
+
+これが効いてくるのが、**締切のあるライフサイクルイベント**である:
+
+| イベント | 締切 | 現状 |
+| --- | --- | --- |
+| ログアウト / 再起動 / シャットダウン | 数秒〜十数秒 | 応答できないと「Emacs がログアウトを中断しました」または強制終了 |
+| `applicationShouldTerminate:` への応答 | あり | `NSTerminateLater` + `replyToApplicationShouldTerminate:` を**使っていない** (下記 2.2) |
+| App Nap 移行 | — | 抑止していないためバックグラウンドでタイマー・プロセスが絞られる |
+| スリープ直前の後始末 | あり | そもそも通知を購読していない |
+
+**この 1 節が作業の本丸で、かつ言語非依存。** ここに手を付けずにデリゲート
+メソッドだけ足しても、肝心の場面 (ログアウト時、スリープ直前) で呼ばれない。
+
+### 1.3 取りうる方針
+
+1. **ポンプ頻度の底上げ** — Emacs の `Vinhibit_quit` / QUIT チェック地点や
+   `atimer` から定期的に `ns_read_socket_1(..., YES)` 相当を回す。
+   影響範囲は小さいが、根本解決にはならない。
+2. **締切のあるイベントだけ別扱い** — `applicationShouldTerminate:` で
+   `NSTerminateLater` を返し、Lisp 側の保存処理完了後に
+   `replyToApplicationShouldTerminate:YES` を呼ぶ。
+   AppKit に「待っている」と伝えられるので強制終了を回避できる。**費用対効果が最も高い。**
+3. **App Nap を明示的に抑止** — `[[NSProcessInfo processInfo]
+   beginActivityWithOptions:NSActivityUserInitiated reason:@"..."]`。
+   数行で効果が出る。
+
+推奨は 2 → 3 → 1 の順。
+
+---
+
+## 2. Emacs 30.2 の実装状況 (実測)
+
+### 2.1 実装済みのデリゲートメソッド (`nsterm.m`)
+
+| メソッド | 行 |
+| --- | ---: |
+| `applicationDidFinishLaunching:` | 6161 |
+| `applicationSupportsSecureRestorableState:` | 6242 |
+| `applicationShouldTerminate:` | 6287 |
+| `application:openFile:` | 6314 |
+| `application:openTempFile:` | 6323 |
+| `application:openFileWithoutUI:` | 6332 |
+| `application:openFiles:` | 6340 |
+| `applicationDockMenu:` | 6357 |
+| `applicationWillBecomeActive:` | 6364 |
+| `applicationDidBecomeActive:` | 6370 |
+| `applicationDidResignActive:` | 6384 |
+
+`NSNotificationCenter` の購読は Cocoa では **1 件だけ**
+(`NSAntialiasThresholdChangedNotification`, `nsterm.m:6176`)。
+`nsterm.m:5918` の画面構成変更の購読は `#ifdef NS_IMPL_GNUSTEP` 限定で、
+Cocoa は `CGDisplayRegisterReconfigurationCallback` (`nsterm.m:5475`) を使う。
+これは妥当な代替なので対応不要。
+
+### 2.2 終了パスが二重で、しかも現代的な作法を使っていない
+
+- `-[EmacsApp terminate:]` (`nsterm.m:6248`) が `NSApplication` の `terminate:` を
+  オーバーライドし、`KEY_NS_POWER_OFF` 非キーイベントを Emacs のキーバッファへ
+  投入する。`lisp/term/ns-win.el:174` で `[ns-power-off]` →
+  `save-buffers-kill-emacs` に束縛されている。
+  **`[super terminate:]` は呼ばない** (実測: `super terminate` は 0 件)。
+- 一方 `applicationShouldTerminate:` (`nsterm.m:6287`) も存在し、
+  `ns-confirm-quit` を見て独自の `NSAlert` を出す。
+- **`NSTerminateLater` と `replyToApplicationShouldTerminate:` はどちらも 0 件。**
+  ログアウト時に「保存処理をしているので待ってほしい」と AppKit に伝える
+  正規の手段を使っていない。
+
+→ ここが §1.3 の方針 2 で直すべき箇所。
+
+### 2.3 未実装のもの (すべて実測で 0 件)
+
+| API | 影響 |
+| --- | --- |
+| `applicationShouldHandleReopen:hasVisibleWindows:` | Dock アイコンをクリックしてもフレームが復活しない。体感的な不満として最も大きい |
+| `application:openURLs:` | `application:openFile(s):` は macOS 10.13 で非推奨。URL スキーム (org-protocol 等) を受けられない |
+| `applicationWillTerminate:` | 終了直前の後始末フックがない |
+| `NSWorkspaceWillSleepNotification` / `DidWakeNotification` | スリープ・復帰を検知できない (タイマー、ネットワーク接続の張り直し) |
+| `NSWorkspaceWillPowerOffNotification` | システム側のログアウト・電源断を検知できない |
+| `NSWorkspaceSessionDidResignActiveNotification` | ファストユーザスイッチに追従できない |
+| `viewDidChangeEffectiveAppearance` / `effectiveAppearance` の KVO | **ダークモードの自動切替が Lisp に伝わらない。** 30.2 は `ns-appearance` フレームパラメータから**設定する**だけ (`-[EmacsWindow setAppearance]`, `nsterm.m:9867`) で、システム側の変更を**観測していない** |
+| `beginActivityWithOptions:` (App Nap) | バックグラウンドで絞られる |
+| `disableSuddenTermination` | 既定が無効なので現状は安全側だが、明示すべき |
+| `encodeRestorableStateWithCoder:` / `restoreStateWithCoder:` | `applicationSupportsSecureRestorableState:` は `YES` を返す (`nsterm.m:6242`) のに、**実際の状態復元は未実装**。macOS 14 の警告を黙らせているだけ |
+| `applicationProtectedDataDidBecomeAvailable:` / `WillBecomeUnavailable:` | FileVault ロック中のファイルアクセスを扱えない |
+
+### 2.4 Info.plist の不足 (`nextstep/templates/Info.plist.in`)
+
+**Emacs の C コードに一切触らずに直せる領域。最も安上がり。**
+
+現状あるもの: `NSPrincipalClass=EmacsApp`、`CFBundleURLTypes` (`mailto` のみ)、
+`NSAppleScriptEnabled`、各種 UsageDescription、`NSAppTransportSecurity`。
+
+不足しているもの:
+
+| キー | 用途 |
+| --- | --- |
+| `LSMinimumSystemVersion` | 最小 macOS の明示。未指定だと古い OS で起動して落ちる |
+| `NSHighResolutionCapable` | Retina 対応の明示 |
+| `LSApplicationCategoryType` | **Mac App Store 配布に必須** (README の目標) |
+| `NSSupportsAutomaticTermination` | 明示 (既定 NO のまま維持でよいが意図を残す) |
+| `NSSupportsSuddenTermination` | 同上。未保存バッファがある以上 NO を明示すべき |
+| `NSSupportsAutomaticGraphicsSwitching` | dGPU 搭載機での電力 |
+| `CFBundleURLTypes` の拡充 | `org-protocol` / `emacs` スキーム (§2.3 の `openURLs:` と対で必要) |
+| `NSUserActivityTypes` | Handoff (任意) |
+| `CFBundleVersion` | 現在 `9.0` 固定。ビルド番号になっておらず配布・notarization で問題 |
+
+---
+
+## 3. 改訂した進め方
+
+Swift 移行計画 (`docs/swift-migration.md` §3) を差し替える。
+
+### Phase 0: Emacs 30.2 へのリベース
+`docs/swift-migration.md` §0 のとおり。パッチ再作成 (`02-...unexmacosx` は
+pdumper 既定化により不要、ns-inline-patch は上流実装により要再評価)、
+`configure` オプション見直し、CI 更新。**検証手段がないので最優先。**
+
+### Phase 1: Info.plist の整備 (§2.4)
+Emacs の C コードに触らない。`build.sh` のパッチ追加だけで完結する。
+効果に対して工数が最小なのでここから。
+
+### Phase 2: 不足しているデリゲートメソッドの追加 (§2.3)
+純粋な Objective-C の追加。1 件あたり数十行。優先順:
+
+1. `applicationShouldHandleReopen:hasVisibleWindows:` — 体感効果が最大
+2. `applicationShouldTerminate:` の `NSTerminateLater` 化 (§2.2) — 締切問題の本命
+3. `NSWorkspace` 通知の購読 — `applicationDidFinishLaunching:` に追記
+4. `viewDidChangeEffectiveAppearance` → ダークモード変更を Lisp へ通知
+5. `application:openURLs:` — Info.plist の URL スキームと対で
+6. `applicationWillTerminate:`
+
+Lisp への通知は既存の `KEY_NS_POWER_OFF` と同じ流儀
+(`nsterm.m:6248` の非キーイベント投入 + `ns-win.el` でのキーバインド) を踏襲するか、
+`DEFVAR_LISP` でフック変数を追加する。
+**いずれも `nsterm.m` / `ns-win.el` 内で完結するため、`docs/swift-migration.md` §2.2 で
+問題にした `make-docfile` の制約には抵触しない。**
+
+### Phase 3: ランループ (§1) — 本丸
+App Nap 抑止、締切のあるイベントへの応答保証、ポンプ頻度の底上げ。
+Phase 2 まで終えた状態で、実機で挙動を測りながら進める。
+
+### Phase 4 (任意): 状態復元
+`encodeRestorableStateWithCoder:` / `restoreStateWithCoder:` の実装。
+`applicationSupportsSecureRestorableState:` が `YES` を返している以上、
+本来は実装すべきだが、Emacs の desktop.el と役割が重複するため設計判断が要る。
+
+---
+
+## 4. 上流還元について
+
+Phase 1〜3 は **すべて上流 GNU Emacs に還元しうる**。
+Swift 移行との決定的な違いがここにある:
+
+- GNUstep を壊さない (`#ifdef NS_IMPL_COCOA` で囲めば済む)
+- 実装言語が Objective-C のまま
+- 機能追加として筋が通っており、`bug-gnu-emacs` / `emacs-devel` で議論可能
+
+条件として、15 行を超える変更には FSF への著作権譲渡 (copyright assignment) が
+必要になる。フォークとして抱え続けるコストと比べれば安い。
+
+方針として、**本リポジトリ固有にすべきもの** (Info.plist、パッケージング、
+署名・notarization) と、**上流に出すもの** (デリゲートメソッド、ランループ)
+を最初から分けてコミットしておくと後が楽になる。
+
+---
+
+## 5. Swift について
+
+`docs/swift-migration.md` に詳細を残してある。要点のみ:
+
+- NS レイヤ 25,464 行のうち ObjC クラス実装は 6,713 行 (26%) しかなく、
+  残り 74% は Emacs コアの C。移行対象は思ったより小さいが、
+- `lisp.h` は Swift から import できない (関数形式マクロ 165 個、
+  `extern inline` 282 個)
+- `DEFUN` / `DEFVAR` を `.swift` に移すと `globals.h` と `etc/DOC` から消える
+  (`make-docfile` は `.c` と `.m` しか走査しない)
+- Emacs のエラーは `longjmp` で飛ぶ (`eval.c:1290` ほか)。Swift フレームを
+  跨ぐ `longjmp` は未定義動作で、ARC の release と `defer` がスキップされる
+- GNUstep 条件分岐 237 箇所を落とすことになり、恒久フォーク化する
+
+**本件の目的 (最新ライフサイクルへの追従) に対して、Swift はコストのみで
+リターンがない。** 将来 Swift 化を検討するとしても、Phase 0〜3 を
+Objective-C で終えた後、`EmacsBell` (85 行、Lisp にも `struct frame` にも
+触らない) のような葉のクラスで実験する程度に留めるのが妥当。

--- a/docs/macos-lifecycle.md
+++ b/docs/macos-lifecycle.md
@@ -2,6 +2,10 @@
 
 対象: GNU Emacs 30.2 (`emacs-30.2` タグ)
 
+> **本書は調査結果 (何が足りないか) をまとめたもの。**
+> 実際の作業手順は **[`roadmap.md`](./roadmap.md)** を参照。
+> 着手する場合はそちらから読むこと。
+
 ## 結論を先に
 
 **Objective-C のまま進められる。Swift は不要。**
@@ -142,55 +146,36 @@ Cocoa は `CGDisplayRegisterReconfigurationCallback` (`nsterm.m:5475`) を使う
 | --- | --- |
 | `LSMinimumSystemVersion` | 最小 macOS の明示。未指定だと古い OS で起動して落ちる |
 | `NSHighResolutionCapable` | Retina 対応の明示 |
-| `LSApplicationCategoryType` | **Mac App Store 配布に必須** (README の目標) |
 | `NSSupportsAutomaticTermination` | 明示 (既定 NO のまま維持でよいが意図を残す) |
 | `NSSupportsSuddenTermination` | 同上。未保存バッファがある以上 NO を明示すべき |
 | `NSSupportsAutomaticGraphicsSwitching` | dGPU 搭載機での電力 |
-| `CFBundleURLTypes` の拡充 | `org-protocol` / `emacs` スキーム (§2.3 の `openURLs:` と対で必要) |
-| `NSUserActivityTypes` | Handoff (任意) |
 | `CFBundleVersion` | 現在 `9.0` 固定。ビルド番号になっておらず配布・notarization で問題 |
+| `CFBundleURLTypes` の拡充 | `org-protocol` / `emacs` スキーム。§2.3 の `openURLs:` と対で入れる |
+
+後回し (`roadmap.md` の Phase 4):
+`LSApplicationCategoryType` (Mac App Store 配布に必須)、
+`NSUserActivityTypes` (Handoff)、サンドボックス関連のエンタイトルメント。
 
 ---
 
-## 3. 改訂した進め方
+## 3. 進め方
 
-Swift 移行計画 (`docs/swift-migration.md` §3) を差し替える。
+**作業手順は [`roadmap.md`](./roadmap.md) に分離した。** 着手する場合はそちらを見ること。
+ここでは全体像だけ示す。
 
-### Phase 0: Emacs 30.2 へのリベース
-`docs/swift-migration.md` §0 のとおり。パッチ再作成 (`02-...unexmacosx` は
-pdumper 既定化により不要、ns-inline-patch は上流実装により要再評価)、
-`configure` オプション見直し、CI 更新。**検証手段がないので最優先。**
+| Phase | 内容 | 根拠 |
+| --- | --- | --- |
+| 0 | Emacs 30.2 へのリベース | `swift-migration.md` §0 |
+| 1 | Info.plist の整備 (Emacs のコードに触らない) | §2.4 |
+| 2 | 不足しているデリゲートメソッドの追加 | §2.3 |
+| 3 | ランループ — 本丸 | §1 |
+| 4 | 後回し: Mac App Store、状態復元、Handoff、iPadOS、Swift | §2.3, §2.4 |
 
-### Phase 1: Info.plist の整備 (§2.4)
-Emacs の C コードに触らない。`build.sh` のパッチ追加だけで完結する。
-効果に対して工数が最小なのでここから。
-
-### Phase 2: 不足しているデリゲートメソッドの追加 (§2.3)
-純粋な Objective-C の追加。1 件あたり数十行。優先順:
-
-1. `applicationShouldHandleReopen:hasVisibleWindows:` — 体感効果が最大
-2. `applicationShouldTerminate:` の `NSTerminateLater` 化 (§2.2) — 締切問題の本命
-3. `NSWorkspace` 通知の購読 — `applicationDidFinishLaunching:` に追記
-4. `viewDidChangeEffectiveAppearance` → ダークモード変更を Lisp へ通知
-5. `application:openURLs:` — Info.plist の URL スキームと対で
-6. `applicationWillTerminate:`
-
-Lisp への通知は既存の `KEY_NS_POWER_OFF` と同じ流儀
+Phase 2 の Lisp への通知は既存の `KEY_NS_POWER_OFF` と同じ流儀
 (`nsterm.m:6248` の非キーイベント投入 + `ns-win.el` でのキーバインド) を踏襲するか、
 `DEFVAR_LISP` でフック変数を追加する。
-**いずれも `nsterm.m` / `ns-win.el` 内で完結するため、`docs/swift-migration.md` §2.2 で
+**いずれも `nsterm.m` / `ns-win.el` 内で完結するため、`swift-migration.md` §2.2 で
 問題にした `make-docfile` の制約には抵触しない。**
-
-### Phase 3: ランループ (§1) — 本丸
-App Nap 抑止、締切のあるイベントへの応答保証、ポンプ頻度の底上げ。
-Phase 2 まで終えた状態で、実機で挙動を測りながら進める。
-
-### Phase 4 (任意): 状態復元
-`encodeRestorableStateWithCoder:` / `restoreStateWithCoder:` の実装。
-`applicationSupportsSecureRestorableState:` が `YES` を返している以上、
-本来は実装すべきだが、Emacs の desktop.el と役割が重複するため設計判断が要る。
-
----
 
 ## 4. 上流還元について
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,391 @@
+# 実装ロードマップ (作業手引き)
+
+**目的: Emacs を最新 macOS のアプリライフサイクルに追従させる。**
+
+このドキュメントは作業を引き継ぐ人 (人間・AI エージェントを問わない) が
+Phase 0 から順に着手できるように書かれた手順書です。
+背景の調査結果は次の 2 つに分けてあります。必要になった時点で参照してください。
+
+| ドキュメント | 内容 | いつ読むか |
+| --- | --- | --- |
+| [`macos-lifecycle.md`](./macos-lifecycle.md) | Emacs 30.2 のライフサイクル実装状況の実測、欠けている API の一覧 | Phase 2 / 3 の着手前 |
+| [`swift-migration.md`](./swift-migration.md) | Swift 化の調査記録。**現行計画ではない** | 「Swift でやるべきでは?」と思ったとき |
+
+---
+
+## 0. 作業を始める前に
+
+### 0.1 前提となる結論 (再検討不要)
+
+以下は調査済みの決定事項です。作業中にこれを覆さないでください。
+理由が必要なら上表のドキュメントを参照してください。
+
+- **Objective-C のまま進める。Swift 化はしない。**
+  AppKit のライフサイクル API に Swift 専用のものは存在しない。
+  Swift はコストのみでリターンがない。
+- **NS レイヤの「素の C」部分 (約 18,700 行) には手を入れない。**
+  `nsfns.m` の 98%、`nsfont.m` / `macfont.m` / `nsselect.m` の 100% は
+  Emacs コアの一部であり、本件の対象外。
+- **GNUstep を壊さない。** 新規コードは `#ifdef NS_IMPL_COCOA` で囲む。
+  これを守れば上流 GNU Emacs に還元できる (§5 参照)。
+- **Mac App Store 対応は後回し** (Phase 4)。
+  `LSApplicationCategoryType`、サンドボックス、エンタイトルメントの見直しは
+  Phase 3 まで終わってから着手する。
+
+### 0.2 やってはいけないこと
+
+- `src/nsterm.m` などの既存ロジックを「ついでに整理する」こと。
+  上流との差分が増えるほど 30.3 / 31 系への追従が苦しくなる。**変更は最小限に。**
+- チェックサムやバージョン番号を**推測で書くこと**。
+  必ず実際に取得した値を使う (§1.2)。
+- 本書中の行番号を検証せずに信じること。
+  すべて `emacs-30.2` タグ時点の実測値だが、パッチ適用後はずれる。
+  **必ず `grep` で現在位置を確認してから編集すること。**
+
+### 0.3 Emacs 30.2 のソース取得
+
+`ftp.gnu.org` は環境によってはネットワークポリシーで遮断されている。
+その場合は GitHub ミラーを使う (調査時はこちらを使用した):
+
+```sh
+git clone --depth 1 --branch emacs-30.2 \
+  https://github.com/emacs-mirror/emacs.git
+```
+
+ただし **ビルドには公式 tarball を使うこと**。git ツリーは `configure` が
+未生成で、`autogen.sh` の実行が必要になり再現性が落ちる。
+ミラーはコード調査用と割り切る。
+
+---
+
+## Phase 0: Emacs 30.2 へのリベース
+
+**これが終わるまで Phase 1 以降は検証できない。最優先。**
+
+現在の `build.sh` は Emacs 26.3 固定。パッチ 5 枚も 26.3 前提で、
+30.2 にはほぼそのまま当たらない。
+
+### 0-A. パッチの棚卸し
+
+| ファイル | 対応 |
+| --- | --- |
+| `00-bump-copyright-year.patch` | **作り直し**。`configure.ac` の対象行が移動している |
+| `01-remove-blessmail.patch` | **要再確認**。`Makefile.in` の構造が変化 |
+| `02-provisional-emacs26.3-unexmacosx.c.patch` | **削除**。理由は下記 |
+| `03-bump-emacs-version.patch` | **作り直し** |
+| `04-macos-big-sur.patch` | **要再評価**。`src/macim.h` を新規追加するもので ns-inline-patch 前提 |
+| `ns-inline-patch` (`emacs-25.2-inline.patch`) | **要再評価**。下記 |
+
+**`02-...unexmacosx` を削除してよい根拠**:
+30.2 は `--with-dumping=pdumper` が既定 (`configure.ac:467`)。
+`unexmacosx.o` がリンクされるのは `--with-dumping=unexec` を明示した場合のみ
+(`configure.ac:2252`)。`src/unexmacosx.c` はツリーに残っているが使われない。
+
+**ns-inline-patch の再評価**:
+30.2 本体に `NSTextInputClient` の実装がある (`nsterm.m:7081`–`7257`)。
+`workingText` の管理 (`nsterm.m:7161`–`7205`)、`ns-working-text` の `DEFVAR`
+(`nsterm.m:11072`)、Lisp 側のオーバーレイ表示 (`lisp/term/ns-win.el:307`–`317` の
+`ns-put-working-text` / `ns-insert-working-text`) が揃っている。
+**まず素の 30.2 をビルドして日本語入力の挙動を実機確認し、
+パッチが本当に必要か判断すること。** 不要ならパッチごと削除でき、
+`04-macos-big-sur.patch` も同時に不要になる。
+
+### 0-B. `build.sh` に `emacs30` を追加
+
+`build_emacs26()` を複製して `build_emacs30()` を作る。
+
+1. `pkgver="30.2"`
+2. **sha256 を実際に取得する。** 推測しないこと:
+   ```sh
+   curl -LO https://ftp.gnu.org/gnu/emacs/emacs-30.2.tar.xz
+   shasum -a 256 emacs-30.2.tar.xz
+   ```
+   可能なら `.sig` での GPG 検証のほうが望ましい:
+   ```sh
+   curl -LO https://ftp.gnu.org/gnu/emacs/emacs-30.2.tar.xz.sig
+   gpg --verify emacs-30.2.tar.xz.sig emacs-30.2.tar.xz
+   ```
+3. パッチ適用行を 0-A の結果に合わせて差し替える
+4. 26.3 のコードパスを残すか消すかは判断に委ねる。
+   維持コストを考えると**消してよい**と考えるが、消す場合は README の
+   Supporting セクションも更新すること。
+
+### 0-C. `configure` オプションの見直し
+
+現行:
+
+```
+--with-ns --with-modules --without-x --without-selinux --without-makeinfo
+--without-mail-unlink --without-mailhost --without-pop --without-mailutils
+--without-jpeg --without-lcms2 --without-gnutls
+```
+
+30.2 の `configure.ac` に対して確認した結果:
+
+- `--without-makeinfo` は **30.2 に存在しないオプション**。
+  `MAKEINFO` は `AC_PATH_PROG` で探されるだけ (`configure.ac:2129`) で、
+  制御するなら `MAKEINFO=true` のように環境変数で渡す。
+  現状は autoconf に黙って無視されている no-op なので**削除する**。
+- それ以外の 10 個は 30.2 でも有効。
+- `--without-jpeg --without-lcms2 --without-gnutls` は issue #2 由来の回避策。
+  **30.2 でも本当に必要か再検証すること。** 不要なら外して機能を戻す。
+
+30.2 で新たに検討できるもの (いずれも任意、Phase 0 では**有効にしない**ことを推奨。
+まず素の状態でビルドを通すのが先):
+
+- `--with-native-compilation` — ビルド時間とバンドルサイズが大幅に増える
+- `--with-tree-sitter`
+- `--with-xwidgets` — `nsxwidget.m` が加わる
+- `--with-json`
+
+### 0-D. 完了条件
+
+- [ ] `sh build.sh emacs30` が最後まで通る
+- [ ] `pkg/Applications/Emacs/Emacs.app` が生成される
+- [ ] `.app` が起動し、`M-x emacs-version` が 30.2 を返す
+- [ ] 日本語入力の挙動を確認し、ns-inline-patch の要否を判断済み
+- [ ] Bitrise CI が緑
+
+---
+
+## Phase 1: Info.plist の整備
+
+**Emacs の C コードに一切触らない。`build.sh` のパッチ追加だけで完結する。**
+工数対効果が最も高いのでここから。
+
+### 1-A. 対象ファイル
+
+テンプレート: `nextstep/templates/Info.plist.in`
+
+生成先: `nextstep/Cocoa/Emacs.base/Contents/Info.plist`
+(`configure.ac:7826` の `AC_CONFIG_FILES` で生成される)
+
+**編集するのはテンプレートのほう。** 生成物を直接いじっても
+`configure` 実行で上書きされる。
+
+### 1-B. 追加するキー
+
+| キー | 値 | 理由 |
+| --- | --- | --- |
+| `LSMinimumSystemVersion` | 決定した最小 macOS | 未指定だと古い OS で起動して落ちる |
+| `NSHighResolutionCapable` | `true` | Retina 対応の明示 |
+| `NSSupportsSuddenTermination` | `false` | 未保存バッファがある以上、明示的に無効化する。既定も `false` だが意図を残す |
+| `NSSupportsAutomaticTermination` | `false` | 同上 |
+| `NSSupportsAutomaticGraphicsSwitching` | `true` | dGPU 搭載機での電力 |
+| `CFBundleVersion` | ビルド番号 | 現在 `9.0` 固定。配布・notarization で問題になる |
+
+**Phase 1 では追加しないもの** (Phase 4 に回す):
+`LSApplicationCategoryType`、`NSUserActivityTypes` (Handoff)、
+サンドボックス関連のエンタイトルメント。
+
+`CFBundleURLTypes` への `org-protocol` / `emacs` スキーム追加は、
+Phase 2 の `application:openURLs:` 実装と**対で入れる**こと。
+片方だけでは動かない。
+
+### 1-C. 進め方
+
+`build.sh` のパッチとして追加する
+(`05-info-plist-lifecycle.patch` のような名前)。
+既存パッチと同じく `patch -p1 -i` で当たる形式にする。
+
+### 1-D. 完了条件
+
+- [ ] ビルド後の `Emacs.app/Contents/Info.plist` に上記キーが入っている
+      (`plutil -p pkg/Applications/Emacs/Emacs.app/Contents/Info.plist` で確認)
+- [ ] `.app` が起動する
+- [ ] `codesign` と notarization が従来どおり通る
+
+---
+
+## Phase 2: 不足しているデリゲートメソッドの追加
+
+純粋な Objective-C の追加。1 件あたり数十行。
+編集対象は `src/nsterm.m` の `@implementation EmacsApp` ブロック
+(`nsterm.m:5896`–`6544`) と `lisp/term/ns-win.el`。
+
+**重要**: 30.2 は Cocoa 側で `NSNotificationCenter` の購読を
+1 件しか行っていない (`NSAntialiasThresholdChangedNotification`,
+`nsterm.m:6176`)。通知の購読は `applicationDidFinishLaunching:`
+(`nsterm.m:6161`) に追記するのが既存の流儀。
+
+**Lisp への通知方法**: 既存の `KEY_NS_POWER_OFF` と同じ流儀を踏襲する。
+`-[EmacsApp terminate:]` (`nsterm.m:6248`) が非キーイベントを
+`kbd_buffer_store_event` で投入し、`lisp/term/ns-win.el:174` で
+`[ns-power-off]` にキーバインドされている。この形なら
+`src/nsterm.m` と `lisp/term/ns-win.el` の中で完結するため、
+`make-docfile` の制約 (`.c` と `.m` しか走査しない) に抵触しない。
+
+### 着手順 (効果の大きい順)
+
+#### 2-A. `applicationShouldHandleReopen:hasVisibleWindows:`
+Dock アイコンをクリックしてもフレームが復活しない問題。
+**体感的な効果が最も大きいのでここから。** 30.2 に実装は一切ない
+(`Reopen` の出現数 0)。
+
+#### 2-B. `applicationShouldTerminate:` の `NSTerminateLater` 化
+**締切問題の本命。** 現状の終了パスには次の問題がある:
+
+- `-[EmacsApp terminate:]` (`nsterm.m:6248`) が `NSApplication` の
+  `terminate:` をオーバーライドし、**`[super terminate:]` を呼ばない**
+  (実測: `super terminate` の出現数 0)
+- `applicationShouldTerminate:` (`nsterm.m:6287`) も別に存在し、
+  `ns-confirm-quit` を見て独自の `NSAlert` を出す
+- **`NSTerminateLater` と `replyToApplicationShouldTerminate:` は
+  どちらも出現数 0** — ログアウト時に「保存中なので待ってほしい」と
+  AppKit に伝える正規の手段を使っていない
+
+`applicationShouldTerminate:` で `NSTerminateLater` を返し、
+Lisp 側の保存完了後に `replyToApplicationShouldTerminate:YES` を呼ぶ形にする。
+これでログアウト・シャットダウン時の強制終了を回避できる。
+
+**注意**: 2 つの終了パスが重複しているため、片方だけ直すと
+Cmd-Q とログアウトで挙動が食い違う。両方の経路を実機で確認すること。
+
+#### 2-C. `NSWorkspace` 通知の購読
+`applicationDidFinishLaunching:` に追記する:
+
+- `NSWorkspaceWillSleepNotification` / `NSWorkspaceDidWakeNotification`
+- `NSWorkspaceWillPowerOffNotification`
+- `NSWorkspaceSessionDidResignActiveNotification` (ファストユーザスイッチ)
+
+**購読先は `[NSWorkspace sharedWorkspace] notificationCenter` であって
+`[NSNotificationCenter defaultCenter]` ではない。** 間違えると通知が来ない。
+
+#### 2-D. ダークモードの自動追従
+30.2 は `-[EmacsWindow setAppearance]` (`nsterm.m:9867`) で
+`ns-appearance` フレームパラメータから外観を**設定する**だけで、
+システム側の変更を**観測していない**
+(`viewDidChangeEffectiveAppearance` / `effectiveAppearance` ともに出現数 0)。
+
+`viewDidChangeEffectiveAppearance` を実装して Lisp にフックを投げる。
+
+#### 2-E. `application:openURLs:`
+`application:openFile:` (`nsterm.m:6314`) 系 4 メソッドは
+macOS 10.13 で非推奨。`application:openURLs:` を追加する。
+Phase 1 で保留した `CFBundleURLTypes` の追加と**対で行う**。
+
+既存の 4 メソッドは互換のため**残すこと** (古い OS と Apple Event 経由の
+呼び出しが残る)。
+
+#### 2-F. `applicationWillTerminate:`
+終了直前の後始末フック。2-B と合わせて設計する。
+
+### 完了条件 (各項目共通)
+
+- [ ] `#ifdef NS_IMPL_COCOA` で囲まれており、GNUstep ビルドを壊さない
+- [ ] 実機で該当イベントを発火させて動作確認済み
+      (スリープ、ログアウト、Dock クリック、ダークモード切替)
+- [ ] 上流に出せる粒度でコミットが分かれている (§5)
+
+---
+
+## Phase 3: ランループ — 本丸
+
+**ここが本質的な問題。Phase 2 まで終えた状態で着手する。**
+
+### 3-A. 何が問題か
+
+Emacs は `NSApplicationMain` を使わない (`nsterm.m:5649` で
+`[EmacsApp sharedApplication]` を呼ぶだけ)。
+イベント処理は Emacs 側が主導し、`ns_read_socket_1` (`nsterm.m:4743`) と
+`ns_select_1` (`nsterm.m:4835`) が **`[NSApp run]` を短時間だけ回して抜ける**
+動作を繰り返す。抜ける手段は自分宛に `NX_APPDEFINED` を投げること
+(`ns_send_appdefined`, `nsterm.m:4663`)。これを
+`-[EmacsApp sendEvent:]` (`nsterm.m:5988`, 説明コメントは `nsterm.m:6035`)
+が捕まえてループを止める。
+
+結果:
+**AppKit のデリゲートコールバックと NSWorkspace 通知は、
+Emacs が `[NSApp run]` の中にいる間 (＝入力待ちの間) しか配送されない。**
+
+Lisp 実行中 (長い font-lock、GC、同期プロセス、Tramp のブロッキング I/O) は
+ポンプしないため、macOS からは応答なしのアプリに見える。
+締切のあるイベント (ログアウト、シャットダウン、App Nap) で失敗するのはここ。
+
+なお `-[EmacsApp run]` のオーバーライド (`nsterm.m:5928`) は
+macOS 10.9 専用の回避策で、現行 macOS では `[super run]` に素通しされる。
+**ここを触る必要はない。**
+
+### 3-B. 取りうる方針 (推奨順)
+
+1. **App Nap の明示的抑止** — 数行で効果が出る。まずこれ。
+   ```objc
+   [[NSProcessInfo processInfo]
+     beginActivityWithOptions:NSActivityUserInitiated
+                       reason:@"..."];
+   ```
+   返り値のトークンを保持し続ける必要がある点に注意。
+2. **締切のあるイベントの別扱い** — Phase 2-B の `NSTerminateLater` 化が
+   これに当たる。Phase 2 で済んでいれば大きな山は越えている。
+3. **ポンプ頻度の底上げ** — Emacs の `atimer` などから定期的に
+   `ns_read_socket_1(..., YES)` 相当を回す。
+   **影響範囲が広く、根本解決にもならない。最後の手段。**
+   ここに手を出す前に、1 と 2 で実用上十分かを実機で測ること。
+
+### 3-C. 完了条件
+
+- [ ] 長い Lisp 処理 (例: 大きなファイルの font-lock) の最中に
+      ログアウトを試み、強制終了されないこと
+- [ ] バックグラウンドでタイマーが絞られないこと
+- [ ] Cmd-Q、Dock からの終了、ログアウトの 3 経路すべてで
+      未保存バッファの確認が正しく出ること
+
+---
+
+## Phase 4: 後回しにしたもの
+
+Phase 3 まで完了してから検討する。着手順は未定。
+
+- **Mac App Store 配布** — `LSApplicationCategoryType`、サンドボックス、
+  エンタイトルメントの全面見直し。Emacs はサブプロセスを起動するため
+  サンドボックス化の難易度が高い。実現性の調査から始めること
+- **状態復元** — `encodeRestorableStateWithCoder:` /
+  `restoreStateWithCoder:`。30.2 は
+  `applicationSupportsSecureRestorableState:` で `YES` を返す
+  (`nsterm.m:6242`) のに実際の復元は未実装、という不整合がある。
+  ただし Emacs の `desktop.el` と役割が重複するため設計判断が必要
+- `applicationProtectedDataDidBecomeAvailable:` (FileVault)
+- Handoff (`NSUserActivityTypes`)
+- **iPadOS** — AppKit は iOS に存在しないため、本ロードマップの延長線上にない。
+  UIKit バックエンドの新規実装であり別プロジェクト規模。
+  参考にすべきは `nsterm` ではなく Emacs 30 の `androidterm.c`
+- **Swift 化** — [`swift-migration.md`](./swift-migration.md) 参照。
+  やるとしても `EmacsBell` (`nsterm.m:1215`–`1300`、85 行、
+  Lisp にも `struct frame` にも触らない) のような葉のクラスでの実験に留める
+
+---
+
+## 5. コミットの分け方 (重要)
+
+Phase 1〜3 の成果は **上流 GNU Emacs に還元しうる**。
+Swift 化との決定的な違いがここにあり、長期の追従コストを大きく下げる。
+
+そのため、最初から次の 2 系統を**別コミットに分けて**おくこと:
+
+| 系統 | 内容 | 行き先 |
+| --- | --- | --- |
+| 上流に出せるもの | `src/nsterm.m` のデリゲートメソッド、ランループ、`lisp/term/ns-win.el`、`nextstep/templates/Info.plist.in` | `emacs-devel` に提案 |
+| 本リポジトリ固有 | `build.sh`、パッケージング、署名・notarization、`package*.xml` | ここで抱える |
+
+上流に出す条件:
+
+- GNUstep を壊さない (`#ifdef NS_IMPL_COCOA` で囲む)
+- 15 行を超える変更には FSF への著作権譲渡 (copyright assignment) が必要
+- 提案先は `bug-gnu-emacs` (バグ) または `emacs-devel` (機能追加)
+
+フォークとして抱え続けるコストと比べれば、譲渡手続きのほうが安い。
+
+---
+
+## 付録: 調査時の実測値について
+
+本書および関連ドキュメント中の行番号・行数は、すべて `emacs-30.2` タグの
+ソースツリーに対する実測値です (調査日: 2026-07-31)。
+
+パッチ適用後や上流の更新でずれるため、**編集前に必ず `grep` で
+現在位置を確認してください。** 例:
+
+```sh
+grep -n 'applicationShouldTerminate' src/nsterm.m
+grep -n '@implementation EmacsApp' src/nsterm.m
+```

--- a/docs/swift-migration.md
+++ b/docs/swift-migration.md
@@ -1,0 +1,316 @@
+# NSTerm の Swift 移行: 対応事項の洗い出し
+
+対象: GNU Emacs 30.2 (`emacs-30.2` タグ) の NeXTstep バックエンド
+
+本書は README の Objective 「Porting Objective-C code to Swift」を実際に着手可能な
+粒度まで分解し、技術的ブロッカーと意思決定事項を列挙したもの。
+以下の数値・行番号はすべて Emacs 30.2 のソースを実際に走査して得たもの。
+
+---
+
+## 0. 前提: 現リポジトリは Emacs 26.3 固定
+
+`build.sh` は 26.3 を対象にしており、Swift 以前に 30.2 へのリベースが必要。
+
+### 0.1 既存パッチの棚卸し
+
+| パッチ | 30.2 での扱い |
+| --- | --- |
+| `00-bump-copyright-year.patch` | 対象行が移動。作り直し |
+| `01-remove-blessmail.patch` | `Makefile.in` の構造が変化。要再確認 |
+| `02-provisional-emacs26.3-unexmacosx.c.patch` | **不要**。30.2 は `--with-dumping=pdumper` が既定 (`configure.ac:467`)。`unexmacosx.o` は `--with-dumping=unexec` を明示した場合のみ使われる (`configure.ac:2252`) |
+| `03-bump-emacs-version.patch` | 作り直し |
+| `04-macos-big-sur.patch` | `src/macim.h` を新規追加するもので ns-inline-patch 前提。下記 0.2 と併せて再評価 |
+| `takaxp/ns-inline-patch` (`emacs-25.2-inline.patch`) | **そのままでは適用不可**。30.2 本体に `workingText` / `NSTextInputClient` 実装がある (`nsterm.m:7081-7257`)。`ns-working-text` は DEFVAR 済み (`nsterm.m:11072`)、`lisp/term/ns-win.el:307-317` に `ns-put-working-text` / `ns-insert-working-text` がありオーバーレイで point 位置に表示される。パッチを維持する必要があるか改めて判定すべき |
+
+### 0.2 configure オプションの見直し
+
+`--without-jpeg --without-lcms2 --without-gnutls` は issue #2 由来の回避策。
+30.2 では `--with-native-compilation`、`--with-tree-sitter`、`--with-xwidgets`、
+`--with-json` など新規オプションが増えているため、方針を決め直す必要がある。
+特に `--with-xwidgets` は `nsxwidget.o` を `NS_OBJC_OBJ` に追加する
+(`configure.ac:4490`) ので、Swift 移行の対象範囲に直接影響する。
+
+---
+
+## 1. 規模の実測: 「NS レイヤ = Objective-C」ではない
+
+移行計画で最初に押さえるべき事実。NS バックエンドの大半は Objective-C ではなく、
+Emacs コアの C API を直接叩く**素の C** である。
+
+| ファイル | 総行数 | ObjC (`@interface`/`@implementation` 内) | 素の C |
+| --- | ---: | ---: | ---: |
+| `src/nsterm.m` | 11,261 | 4,965 (44%) | 6,296 (55%) |
+| `src/nsfns.m` | 4,070 | 69 (1%) | 4,001 (98%) |
+| `src/macfont.m` | 4,257 | 0 (0%) | 4,257 (100%) |
+| `src/nsmenu.m` | 2,039 | 1,045 (51%) | 994 (48%) |
+| `src/nsfont.m` | 1,765 | 0 (0%) | 1,765 (100%) |
+| `src/nsselect.m` | 825 | 0 (0%) | 825 (100%) |
+| `src/nsxwidget.m` | 637 | 281 (44%) | 356 (55%) |
+| `src/nsimage.m` | 610 | 353 (57%) | 257 (42%) |
+| **合計** | **25,464** | **6,713 (26%)** | **18,751 (74%)** |
+
+ヘッダを含めると 27,164 行 (`nsterm.h` 1,387 / `nsgui.h` 143 / `macfont.h` 88 / `nsxwidget.h` 82)。
+
+**帰結**: 「NSTerm を Swift へ」の実作業対象は 25,464 行全体ではなく、
+ObjC クラス実装の 6,713 行。残り 74% は Emacs コアの一部であり、
+Swift 化しても利点がなく §2.3 / §2.4 のリスクだけが増える。**非目標とすべき。**
+
+### 1.1 移行対象クラス一覧
+
+`nsterm.h` が宣言するクラス (行番号は `nsterm.h`)、実装位置は `nsterm.m`:
+
+| クラス | 宣言 | 実装 | 実装行数 |
+| --- | ---: | ---: | ---: |
+| `NSColor (EmacsColor)` | 357 | 151–200 | 49 |
+| `NSString (EmacsString)` | 366 | — | — |
+| `EmacsBell` | (`nsterm.m:1203`) | 1215–1300 | 85 |
+| `EmacsApp` | 378 | 5896–6544 | 648 |
+| `EmacsView` | 466 | 6671–9233 | 2,562 |
+| `EmacsWindow` | 419 | 9243–10079 | 836 |
+| `EmacsScroller` | 706 | 10089–10586 | 497 |
+| `EmacsLayer` | 744 | 10597–10864 | 267 |
+| `EmacsDocument` | 405 | 10872–10874 | 2 |
+| `EmacsMenu` / `EmacsToolbar` / `EmacsDialogPanel` / `EmacsTooltip` / `EmacsFileDelegate` | 540/565/602/632/654 | `nsmenu.m` | 1,045 |
+| `EmacsImage` | 670 | `nsimage.m` | 353 |
+| `XwWebView` | (`nsxwidget.m:51`) | `nsxwidget.m` | 281 |
+
+---
+
+## 2. 技術的ブロッカー
+
+### 2.1 `lisp.h` を Swift から import できない
+
+- `src/lisp.h` には**関数形式マクロが 165 個、`INLINE` 関数が 282 個**ある。
+- Swift の Clang importer は**関数形式マクロを一切取り込まない**。
+  `XCAR` / `XCDR` / `CONSP` / `CHECK_STRING` / `make_fixnum` / `AREF` / `SDATA` /
+  `BVAR` などが全滅する。
+- `INLINE` は `conf_post.h:417,437` で `EXTERN_INLINE` (C99 `extern inline`) に
+  展開される。`static inline` と違い定義の実体は 1 つの TU にしか出ないため、
+  importer からの参照はリンク時解決に依存し不安定。
+
+**対応**: Swift から使う Emacs C API だけを通常の (inline でない) 関数として
+再公開する薄いシム層 `src/emacs_swift_shim.h` / `.c` を新設し、
+bridging header ではそれだけを露出する。
+これは実質「Swift 用 Emacs C API ラッパの新規実装」であり、移行コストの中心。
+シムの API 面積を小さく保てるかが全体の成否を決める。
+
+### 2.2 `DEFUN` / `DEFVAR` が Swift で書けない — かつビルド生成物から消える
+
+`lisp.h:3471` の定義:
+
+```c
+#define DEFUN(lname, fnname, sname, minargs, maxargs, intspec, doc) \
+  SUBR_SECTION_ATTRIBUTE                                            \
+  static union Aligned_Lisp_Subr sname =                            \
+     {{{ PVEC_SUBR << PSEUDOVECTOR_AREA_BITS },                     \
+       { .a ## maxargs = fnname },                                  \
+       minargs, maxargs, lname, {intspec}, lisp_h_Qnil}};           \
+   Lisp_Object fnname
+```
+
+セクション属性付きの `static union` + 指定初期化子。Swift に等価物はない。
+
+さらに深刻なのがビルド生成物への影響:
+
+- `src/Makefile.in:712` — `GLOBAL_SOURCES = $(base_obj:.o=.c) $(NS_OBJC_OBJ:.o=.m)`
+- `src/Makefile.in:714-719` — `GLOBAL_SOURCES` から `make-docfile -g` で `globals.h` を生成
+- `src/Makefile.in:695-698` — 同じく `etc/DOC` を生成
+- `lib-src/make-docfile.c:783,800` — スキャン対象は **`.c` と `.m` のみ**
+
+つまり `.swift` に移した `DEFUN` / `DEFVAR` は `globals.h` にも `etc/DOC` にも
+現れず、ビルドが壊れるか docstring が消える。
+
+対象となる定義数: `nsfns.m` に `DEFUN` 45 個、`nsselect.m` 6 個、`nsmenu.m` 2 個、
+加えて `nsterm.m` の `DEFVAR_LISP` 群。
+
+**対応**: (a) `DEFUN` / `DEFVAR` と `syms_of_*` は C/ObjC 側に残す (推奨)、
+または (b) `make-docfile.c` に `.swift` スキャナを追加し `Makefile.in` を改造する。
+(a) なら §1 の「素の C は非目標」方針と自然に一致する。
+
+### 2.3 `longjmp` による非局所脱出 — 最大の正当性リスク
+
+- Emacs のエラー / `throw` は `sys_setjmp` / `sys_longjmp` (`lisp.h:2293-2304`)。
+  実際の脱出点は `eval.c:1290`, `1361`, `1537`, `1604`, `1628`, `1655`。
+- `error()`, `xsignal()`, `CHECK_*` など**極めて多くの Emacs C API が signal しうる**。
+- Swift は setjmp/longjmp によるフレーム飛び越しを**未定義動作**としている。
+  ARC の release、`defer`、`deinit` がすべてスキップされ、リークまたは二重解放になる。
+
+**対応**: Swift フレームから Emacs C を呼ぶ境界を「絶対に signal しない関数」に
+限定する。signal しうる呼び出しは `internal_condition_case_1` / `internal_catch`
+で C 側にラップし、結果だけを Swift に返す。
+この境界設計を怠ると再現困難なクラッシュになるため、シム層 (§2.1) の設計時点で
+「signal しうる / しない」を型か命名規約で分離しておくこと。
+
+### 2.4 GC の保守的スタックスキャン
+
+- `alloc.c:5274` `mark_memory()` / `alloc.c:5493` がスタックを生スキャンし、
+  `alloc.c:5456` 付近の `__builtin_unwind_init` でレジスタを退避する。
+- Swift のローカル変数に置いた `Lisp_Object` (実体は `Lisp_Word`、`lisp.h:586,592`)
+  は原則スキャンされる。しかし Swift がその値を**エスケープするクロージャの
+  コンテキストや箱としてヒープに置いた場合、GC の走査対象外**となり回収される。
+
+**対応**: `Lisp_Object` を Swift のエスケープするクロージャ / プロパティ / 配列に
+保持しない。保持が必要なら `staticpro` するか、Lisp 側のデータ構造に持たせる
+(Emacs は `GCPRO` を廃止済みなので代替手段はこの 2 つ)。
+Swift 側では `Lisp_Object` を「短命な不透明値としてのみ扱う」規約を明文化する。
+
+### 2.5 GNUstep サポートを落とすことになる = 恒久フォーク
+
+- `NS_IMPL_GNUSTEP` / `NS_IMPL_COCOA` の条件分岐は **237 箇所**
+  (`nsterm.m` 137、`nsfns.m` 42、`nsterm.h` 30、`nsmenu.m` 23、`nsselect.m` 3、`nsimage.m` 2)。
+- Swift に C プリプロセッサはない。`#if` は Swift の条件コンパイル (`-D`) に
+  置き換えられるが、そもそも **GNUstep 環境に AppKit 付きの Swift Foundation がない**。
+- 結果として GNUstep サポートは事実上放棄となる。
+
+**帰結**: この作業は上流 GNU Emacs に還元できない。加えて GNU プロジェクトは
+実装言語として C 以外を受け付けず、著作権譲渡も必要。
+**上流マージを想定しない恒久フォーク**として計画すべき。
+上流の 30.3 / 31 系への追従コストを誰がどう払うかを先に決めること。
+
+### 2.6 ObjC ↔ Swift 相互運用とヘッダの循環
+
+- Swift クラスを ObjC から使うには `NSObject` 継承 + `@objc` が必要。
+  `EmacsView : NSView` 等はこれを満たすので Swift 側での定義自体は可能。
+- 問題は `nsterm.h` の `struct ns_output` が ObjC 型を直接メンバに持つこと:
+
+  ```c
+  struct ns_output {
+  #ifdef __OBJC__
+    EmacsView *view;
+    ...
+    EmacsToolbar *toolbar;
+  #else
+    void *view;
+    ...
+  #endif
+  ```
+
+- ここで include が循環する:
+  - Swift は bridging header 経由で `nsterm.h` (`struct ns_output`, `struct frame`) を必要とする
+  - `nsterm.h` は `EmacsView` (= Swift 生成ヘッダ `Emacs-Swift.h`) を必要とする
+
+**対応**: `@class EmacsView;` の前方宣言だけを別ヘッダに切り出す、
+または当該メンバを `void *` に統一して Swift 側で `Unmanaged` 経由で扱う。
+いずれにせよ **2 フェーズビルド** (`swiftc -emit-objc-header-path` →
+生成ヘッダを include して `clang`) を Makefile に組み込む必要がある。
+
+- 併せて、旧 API `NSTextInput` 準拠が 6 箇所残っている
+  (`nsterm.h:466-468`, `nsterm.m:7041-7067`)。
+  Swift で非推奨プロトコルを採用するのは扱いが面倒なので、
+  `NSTextInputClient` への一本化を前提条件とする。
+
+### 2.7 ビルドシステム: autotools に Swift サポートがない
+
+- `src/Makefile.in:455` — `.SUFFIXES: .c .m .cc`。**`.swift` はない。**
+- 暗黙ルールは `.m.o:` (`Makefile.in:458`) のみ。
+- Swift は whole-module compilation が前提で、**1 ファイル = 1 オブジェクトという
+  make のモデルと噛み合わない**。
+
+必要な作業:
+- `configure.ac` に `swiftc` 検出 (`AC_CHECK_TOOL`)、`SWIFT_OBJ` / `SWIFTFLAGS` /
+  `AC_SUBST` を追加
+- `src/Makefile.in` に Swift モジュールを 1 オブジェクトにまとめるルールと
+  `-emit-objc-header-path` を追加
+- 依存関係生成 (Swift は `-MD` 相当が C ほど成熟していない) と
+  `make bootstrap` / `make -j` との整合
+- Bitrise CI の Xcode バージョン固定 (現状 badge のみで設定内容は本リポジトリ外)
+
+**Swift ランタイム**: macOS 10.14.4 以降は ABI 安定により OS 同梱。
+それ以降をターゲットにすれば `.app` への埋め込みは不要で、
+既存の `codesign --deep` / notarization フローに追加作業は生じない。
+10.14.3 以前を切るかどうかがバンドル構成の分岐点。
+
+### 2.8 pdumper との相互作用
+
+- 30.2 の既定は `--with-dumping=pdumper` (`configure.ac:467`)。
+- **Swift のグローバル変数は `swift_once` による遅延初期化**。
+  pdumper は C ヒープをダンプ・復元するため、Swift ランタイム管理下の状態を
+  ダンプ越しに持ち越すと不整合を起こす。
+- NS 側には既に pdumper フックがある: `syms_of_nsfont_for_pdumper` (`nsfont.m:1762`)。
+
+**対応**: Swift 側にグローバル可変状態を置かない。状態はすべて C の struct
+(`ns_display_info` / `ns_output`) 側に持たせる。
+temacs のダンプ時は GUI が初期化されないため通常は顕在化しないが、
+規約として明文化しておかないと後から踏む。
+
+### 2.9 スレッドと Swift Concurrency
+
+- `ns_select` (`nsterm.m:5002`, 実体は `ns_select_1` `nsterm.m:4835`) が
+  NSApp のランループと Emacs の `thread_select` / `pselect` を統合している
+  (`nsterm.m:4873-4883`)。
+- `ns_read_socket` (`nsterm.m:4828`) が入力イベントを Emacs 側へ渡す。
+- Emacs Lisp スレッドは協調的で、AppKit コールバックはメインスレッド前提。
+
+**対応**: Swift 化部分で `async` / `await` / `actor` を使わない。
+暗黙のスレッドホップが起きると「メインスレッド以外から Lisp を触らない」という
+Emacs コアの前提を壊す。使うのは `@MainActor` の明示のみに留める。
+
+### 2.10 iPadOS 対応 (README の目標) には直結しない
+
+- **AppKit は iOS/iPadOS に存在しない。** NSTerm の Swift 化は iPadOS 対応の
+  前段にならない。必要なのは UIKit バックエンドの新規実装であり、別プロジェクト規模。
+- 参考にすべきは `nsterm` ではなく、Emacs 30 に既にある非デスクトップ
+  バックエンド `androidterm.c` / `androidfns.c` (`src/Makefile.in:502`)。
+- README の目標としては維持してよいが、本移行のスコープからは外すべき。
+
+---
+
+## 3. 推奨する進め方
+
+### Phase 0: 30.2 ベースのビルド復旧 (Swift 以前)
+§0 の全項目。パッチ再作成、`configure` オプション見直し、CI 更新。
+**ここが終わらないと以降の検証手段がない。** 最優先。
+
+### Phase 1: 境界の整備 (Swift ファイル 0 個)
+- `emacs_swift_shim.h/.c` 導入 (§2.1)、signal 境界の規約決定 (§2.3)
+- `nsterm.h` から ObjC クラス宣言を分離し include 循環を解消 (§2.6)
+- `configure.ac` / `Makefile.in` に 2 フェーズビルドを導入 (§2.7)
+- この状態で `make bootstrap` が通ることを確認する
+
+### Phase 2: 葉のクラスから移行 (依存の少ない順)
+1. **`EmacsBell`** (`nsterm.m:1215-1300`, 85 行) — 純粋な `NSImageView`。
+   Lisp にも `struct frame` にも触らないことを確認済み。**最初の 1 本に最適。**
+2. `EmacsLayer` (267 行) — `CALayer`、描画バッファのみ
+3. `EmacsScroller` (497 行) — Lisp との接点は少量
+4. `EmacsImage` (`nsimage.m`, 353 行)
+
+### Phase 3
+`EmacsWindow` (836 行)、`EmacsMenu` / `EmacsToolbar` ほか (`nsmenu.m`, 1,045 行)
+
+### Phase 4 (最難関)
+`EmacsApp` (648 行)、`EmacsView` (2,562 行)。
+`EmacsView` は `NSTextInputClient`・描画・イベント処理のすべてが Lisp と密結合。
+
+### 非目標
+素の C 部分 18,751 行 (§1)。特に `nsfns.m` (98% が C)、`nsfont.m` / `macfont.m` /
+`nsselect.m` (100% が C) は Swift 化の対象外とする。
+`ns_redisplay_interface` の関数テーブル (`nsterm.m:5437-5471`, 27 スロット) も同様。
+
+---
+
+## 4. 先に決めるべき意思決定事項
+
+1. **上流還元を諦めるか** — GNUstep 放棄と GPLv3 フォーク維持を受け入れるか (§2.5)。
+   受け入れる場合、上流 30.3 / 31 系への追従方針を併せて決める
+2. **最小 macOS バージョン** — 10.14.4 が Swift ランタイム同梱の境界 (§2.7)
+3. **ns-inline-patch を維持するか** — 30.2 上流の `ns-working-text` に寄せるか (§0.1)
+4. **Xcode プロジェクト化するか autotools を拡張するか** —
+   README の "Support Xcode" 目標との関係 (§2.7)
+5. **ObjC を完全に無くすのか** — §2.2 の理由から、`DEFUN` / `syms_of_*` 用の
+   薄い `.m` を残すのが現実的
+6. **`--with-xwidgets` を有効にするか** — `nsxwidget.m` (281 行の ObjC) が
+   移行対象に加わる (§0.2)
+
+---
+
+## 5. 調査に使った環境
+
+Emacs 30.2 のソースは `ftp.gnu.org` が本作業環境のネットワークポリシーで
+遮断されていたため、GitHub ミラーの `emacs-30.2` タグから取得した:
+
+```sh
+git clone --depth 1 --branch emacs-30.2 https://github.com/emacs-mirror/emacs.git
+```
+
+本書中の行番号・行数はこのツリーに対する実測値。

--- a/docs/swift-migration.md
+++ b/docs/swift-migration.md
@@ -1,5 +1,15 @@
 # NSTerm の Swift 移行: 対応事項の洗い出し
 
+> **本書は「Swift 化すると何が必要になるか」の調査記録であり、現行の計画ではない。**
+>
+> 目的が「最新 macOS のアプリライフサイクルへの追従」である場合、Swift 化は不要。
+> AppKit のライフサイクル API はすべて Objective-C から利用でき、Swift 専用の
+> ものは一つもない。実際の障害は言語ではなく Emacs のランループ構造にある。
+> 現行の計画は **[`macos-lifecycle.md`](./macos-lifecycle.md)** を参照。
+>
+> 本書は「なぜ Swift を採らないか」の根拠 (§2 のブロッカー一覧) と、
+> NS レイヤの規模の実測値 (§1) として引き続き有効。
+
 対象: GNU Emacs 30.2 (`emacs-30.2` タグ) の NeXTstep バックエンド
 
 本書は README の Objective 「Porting Objective-C code to Swift」を実際に着手可能な


### PR DESCRIPTION
Enumerate the work required to rebase onto Emacs 30.2 and port the
NeXTstep backend from Objective-C to Swift.

Measured against the emacs-30.2 tag: the NS layer is 25,464 lines, but
only 6,713 (26%) are Objective-C class implementations -- the remaining
74% is plain C calling Emacs internals and should stay as-is.

Documents the blockers found in the source: lisp.h is not importable
into Swift (165 function-like macros, 282 extern inline functions),
DEFUN/DEFVAR cannot be expressed in Swift and would vanish from
globals.h and etc/DOC because make-docfile only scans .c and .m,
longjmp-based nonlocal exit is undefined behavior across Swift frames,
conservative GC stack scanning conflicts with escaping Swift closures,
237 GNUstep conditionals make the port a permanent fork, the ObjC/Swift
header cycle around struct ns_output, autotools has no .swift suffix
rule, pdumper conflicts with Swift lazy global init, and AppKit's
absence on iPadOS.

Also inventories the existing 26.3 patch stack (02-unexmacosx is
obsolete under pdumper; ns-inline-patch is superseded upstream) and
proposes a phased plan starting from EmacsBell.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014BLmKYRkadtTeNATYfGnKn