### PR TITLE
Check bitrise.yml into the repository and build emacs26 in the primary workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 src
 pkg
+.bitrise.secrets.yml

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -52,7 +52,7 @@ workflows:
             # debug log
             set -x
 
-            bash build.sh emacs-ipad
+            bash build.sh emacs26
     - script@1:
         inputs:
         - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,0 +1,139 @@
+---
+format_version: '8'
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+project_type: other
+trigger_map:
+- push_branch: "*"
+  workflow: primary
+- pull_request_source_branch: "*"
+  workflow: primary
+workflows:
+  primary:
+    steps:
+    - activate-ssh-key@4:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            xcodebuild -version
+        title: Echo xcodebuild version
+    - git-clone@8.5:
+        inputs:
+        - submodule_update_depth: '1'
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+            set -o pipefail
+            # debug log
+            set -x
+
+            brew update
+        title: brew update
+    - brew-install@1.0:
+        inputs:
+        - packages: autoconf automake pkg-config gnutls texinfo python@3.13 xz azure-cli
+    - script@1:
+        title: build.sh
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            bash build.sh emacs-ipad
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            tar cJvf pkg.tar.xz pkg/Applications/Emacs
+            filename="daily/catalina/emacs-26.3_`date -u +%Y%m%d_%H%M%S_UTC`.tar.xz"
+
+            az login -u $az_ad_account -p $az_ad_password
+            az storage blob upload -c macos --auth-mode login --account-name emacsonapple --file pkg.tar.xz --name $filename
+        title: Deploy to Azure Storage Blob
+    - slack@4:
+        inputs:
+        - webhook_url: "$slack_webhook_url"
+    meta:
+      bitrise.io:
+        stack: osx-xcode-16.4.x
+  release:
+    steps:
+    - activate-ssh-key@4:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            xcodebuild -version
+        title: Echo xcodebuild version
+    - git-clone@4: {}
+    - brew-install@0:
+        inputs:
+        - packages: autoconf automake pkg-config gnutls texinfo python xz azure-cli
+    - script@1:
+        title: Build Emacs.app
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            bash build.sh emacs26
+    - script@1:
+        title: Codesign Emacs.app
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            bash build.sh codesign "$developer_id_application"
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            tar cJvf pkg.tar.xz pkg/Applications/Emacs
+            filename="release/catalina/emacs-26.3_`date -u +%Y%m%d_%H%M%S_UTC`.tar.xz"
+
+            az login -u $az_ad_account -p $az_ad_password
+            az storage blob upload -c macos --auth-mode login --account-name emacsonapple --file pkg.tar.xz --name $filename
+        title: Deploy to Azure Storage Blob
+    - slack@3:
+        inputs:
+        - webhook_url: "$slack_webhook_url"
+meta:
+  bitrise.io:
+    stack: osx-xcode-16.4.x
+    machine_type_id: g2.mac.medium


### PR DESCRIPTION
Investigation of the Bitrise build failure ([build f46e5652](https://app.bitrise.io/app/6ab4eec93dedce2f/build/f46e5652-82d7-4f33-b681-5f6061641a52)) turned up several separate problems. This PR lands the two that are ready; the rest are deferred to the Emacs 30.2 work.

## What this PR changes

**Check the CI configuration into the repository.** `bitrise.yml` was only stored on bitrise.io, so the workflow definition was neither reviewable nor versioned alongside the code it builds. It is committed here verbatim as exported. Credentials are referenced only through environment variables (`$az_ad_account`, `$az_ad_password`, `$slack_webhook_url`, `$developer_id_application`) and stay in Bitrise Secrets, so no secret material is checked in. `.bitrise.secrets.yml` is added to `.gitignore` so a local secrets file used with the Bitrise CLI is never committed by accident.

Note that checking the file in does not by itself take effect — the configuration source still has to be switched from bitrise.io to Repository in the Bitrise app settings.

**Build `emacs26` in the primary workflow.** The workflow invoked `build.sh emacs-ipad`, but `build.sh` has no such command: its case statement accepts only `help`, `clean`, `codesign` and `emacs26`, so the invocation fell through to the catch-all, printed `Unknown command` and exited 1. The `emacs-ipad` target no longer exists in the tree. Restoring an iPad target is separate work.

## Why the build was failing

The reported build never reached `build.sh` at all — it died in the `Brew install` step, and every later step was skipped.

```
==> Pouring texinfo--7.3.arm64_sequoia.bottle.1.tar.gz
Error: unknown install step: run
  Library/Homebrew/install_steps.rb:339 ... run_install_step
  Library/Homebrew/formula.rb:1619    ... run_post_install_steps
```

This is a version skew between the Homebrew client and the formula API, not a configuration error:

| | |
|---|---|
| Homebrew on stack image `2-142-0` | 6.0.6, tagged 2026-06-29 |
| `run` install step added | 2026-07-26, commit `cf5bc21c6b` |
| First release containing it | 6.0.13 |
| Build date | 2026-07-31 |

`HOMEBREW_NO_INSTALL_FROM_API` is unset, so formula definitions come from the evergreen JSON API while the client stays pinned to whatever the stack image ships. When `texinfo`'s `post_install` moved to a `run` step, the 6.0.6 client no longer understood it. The formulae installed before `texinfo` succeeded because none of them declare a `run` step.

A `brew update` step already present in the exported YAML addresses this by upgrading the client past 6.0.13. `brew-install` still leaves `upgrade` at its default of `yes` (i.e. `brew reinstall`), so if `brew update` cannot advance the client far enough, the same failure returns; setting `upgrade: "no"` would avoid running `post_install` for already-installed formulae.

## Deferred to the Emacs 30.2 work

Three further blockers were found and reproduced but are intentionally not addressed here:

1. **ns-inline-patch checksum mismatch.** `build.sh` clones the patch repository at branch HEAD while comparing against a hardcoded SHA-256. The pinned value matches revision `e0d93e2` (2020-01-08); upstream HEAD is `f66a96d` (2020-11-10), so the check fails and the script exits before `configure`. The root cause is pinning the content without pinning the source.
2. **Double-applied patch.** Upstream's current inline patch now supplies `src/macim.h` and the `#include "macim.h"` lines that `04-macos-big-sur.patch` also adds, so the two collide. Applying the chain against Emacs 26.3 produces `.rej` files for `src/nsfns.m` and `src/nsterm.m`, and `patch` exits 1, which `set -e` turns into a build failure. Bumping the checksum alone therefore does not fix (1).
3. **Emacs 26.3 on current hardware.** The stack is macOS Sequoia on Apple Silicon with Xcode 16.4. Emacs 26.3 dumps via `unexec`, which does not work there; `pdumper` arrived in 27.1.

Since (3) likely forces a version bump regardless, (1) and (2) are best resolved as part of moving to 30.2 rather than patched twice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dpsx2HijbgzLQZyxonwV3a)_