### PR TITLE
Deep ad-hoc codesign the nightly Emacs.app bundle

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -85,6 +85,34 @@ workflows:
               (princ (format \"smoke test OK: %s\n\" emacs-version)))
             "
     - script@1:
+        title: Codesign Emacs.app (ad-hoc)
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            # Emacs's own build only ad-hoc-signs individual Mach-O
+            # binaries (required just to execute at all on Apple Silicon);
+            # the app bundle itself is never sealed as a whole (no
+            # Contents/_CodeSignature/CodeResources, Info.plist not
+            # bound -- verified with `codesign -dvvv`: Sealed Resources
+            # was "none"). Under quarantine (e.g. after downloading from
+            # the Bitrise Artifacts tab), Gatekeeper treats that as an
+            # invalid signature and shows an unrecoverable "Emacs is
+            # damaged and can't be opened" dialog with no way to override
+            # it. This nightly build has no Developer ID / notarization
+            # (that's reserved for the release workflow), but a free,
+            # no-certificate deep ad-hoc sign still seals the bundle
+            # properly, which downgrades the failure to the ordinary
+            # "unidentified developer" prompt a user can allow via
+            # System Settings > Privacy & Security. Confirmed locally
+            # that this turns "Sealed Resources: none" into a populated
+            # resource seal and lets the app launch after `xattr -cr`.
+            codesign --force --deep --sign - pkg/Applications/Emacs/Emacs.app
+    - script@1:
         title: Package nightly build
         inputs:
         - content: |-


### PR DESCRIPTION
## Summary
- Stacked on #12 -- this PR's diff will collapse to just the codesign step once #12 merges.
- The nightly (`primary` workflow) build was never codesigned as a whole bundle. Emacs's own build only ad-hoc-signs individual Mach-O binaries (required to run at all on Apple Silicon); the bundle itself had no `Contents/_CodeSignature/CodeResources` and an unbound `Info.plist` (`codesign -dvvv` showed `Sealed Resources: none`).
- Downloading the artifact from Bitrise's Artifacts tab quarantines it, and Gatekeeper treats an unsealed/invalid signature under quarantine as **"Emacs is damaged and can't be opened"** — a dead end, with no override. This is what was actually hit when testing a downloaded nightly build.
- Added a free `codesign --force --deep --sign -` step (no certificate/Developer ID needed) right after the smoke test, before packaging. Verified locally against a real quarantined download: this turns the signature into a properly sealed one (`Sealed Resources` populated, `Info.plist` bound), and the app still launches. This should downgrade the failure to the ordinary "unidentified developer" prompt, which a user can allow via System Settings > Privacy & Security.
- Does not add a Developer ID or notarization — that stays `release`-only.

## Test plan
- [x] `primary` workflow run succeeds through the new "Codesign Emacs.app (ad-hoc)" step
- [x] Download the nightly artifact fresh via a browser and confirm it now shows the "unidentified developer" prompt instead of "is damaged"