### PR TITLE
Scope push_branch to master to stop duplicate CI builds

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,7 +3,17 @@ format_version: '8'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: other
 trigger_map:
-- push_branch: "*"
+# push_branch is intentionally scoped to master only, not "*". With both
+# push_branch: "*" and pull_request_source_branch: "*", pushing to a branch
+# that already has an open PR fired two builds for the same commit (one from
+# each webhook event). Branches without an open PR now get no CI at all
+# until a PR exists; master itself still gets a post-merge sanity build.
+# pull_request_source_branch stays "*" (not narrowed) because this repo
+# accepts external PRs from forks, and a fork's pushes never fire a
+# push_branch event against this repo -- pull_request is the only trigger
+# that can see them.
+# https://discuss.bitrise.io/t/build-on-the-same-commit-sha-triggered-twice/4413
+- push_branch: master
   workflow: primary
 - pull_request_source_branch: "*"
   workflow: primary


### PR DESCRIPTION
## Summary
- `trigger_map` had both `push_branch: "*"` and `pull_request_source_branch: "*"`. Pushing to a branch that already has an open PR fires both webhooks, so Bitrise ran two builds for the same commit (once from the push event, once from the pull_request synchronize event). This happened on every PR pushed in this session (#12, #13), doubling macOS build minutes -- the most expensive machine type.
- Narrowed `push_branch` to `master` only:
  - branch with no open PR: no CI until a PR exists (was 1 build per push)
  - branch with an open PR: 1 build via the PR sync trigger (was 2)
  - PR opened/updated: 1 build (unchanged)
  - push to `master`: 1 build, kept as a post-merge sanity check
- `pull_request_source_branch: "*"` is left as-is on purpose: this repo accepts external PRs (per README), and a fork's pushes never generate a `push_branch` event against this repo -- `pull_request` is the only trigger that can see fork-based PRs at all.

Source: https://discuss.bitrise.io/t/build-on-the-same-commit-sha-triggered-twice/4413

## Test plan
- [x] Push a commit to a branch with no open PR yet -> confirm no Bitrise build starts
- [x] Open a PR from that branch -> confirm exactly one build starts
- [x] Push another commit to that same open PR's branch -> confirm exactly one build starts (not two)
- [x] Merge to `master` -> confirm exactly one build starts


Verified in #15: no build on push before a PR existed, exactly one `.../pr` check on PR open, exactly one `.../pr` check (not two) on a follow-up push to the open PR, and exactly one `.../push` check on merge to master.