### PR TITLE
Add missing brew update to the release workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -168,6 +168,19 @@ workflows:
             xcodebuild -version
         title: Echo xcodebuild version
     - git-clone@4: {}
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+            set -o pipefail
+            # debug log
+            set -x
+
+            brew update
+        title: brew update
     - brew-install@0:
         inputs:
         - packages: autoconf automake pkg-config gnutls texinfo python xz gh


### PR DESCRIPTION
## Summary
- `release` went straight from `git-clone` to `brew-install`, unlike `primary` (which runs `brew update` first).
- Manually triggering `release` (tag `v30.2-test-release-workflow`, for end-to-end verification of the GitHub Releases publishing change) failed at the Brew install step:
  ```
  Error: unknown install step: run
  .../formula.rb:1618:in 'Formula#run_post_install_steps'
  Can't install formulas: exit status 1
  ```
- `texinfo`'s bottle metadata used a post-install step format the pre-baked Homebrew CLI on the runner didn't understand -- exactly the client/formula-schema skew `brew update` exists to prevent (it updates the Homebrew CLI itself, not just formula definitions). `primary` hasn't hit this because it already updates first.
- Added the same `brew update` step to `release`, mirroring `primary`.

## Test plan
- [x] Re-run the `release` workflow against the same test tag and confirm it gets past Brew install this time (confirmed -- the re-run got past Brew install and reached the Codesign step, which is where #17's fix picked up)
