### PR TITLE
Fix release asset filename on GitHub Releases

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -266,7 +266,12 @@ workflows:
             : "${BITRISE_GIT_TAG:?release workflow must be triggered from a git tag}"
             export GH_TOKEN="$github_token"
 
-            tar cJvf pkg.tar.xz pkg/Applications/Emacs
+            # `gh release upload local-path#label` only sets a cosmetic
+            # display label -- the asset's real name (and download URL)
+            # stays the local file's basename. Rename before uploading so
+            # the actual downloaded file is named sensibly.
+            asset="emacs-${BITRISE_GIT_TAG}-macos.tar.xz"
+            tar cJvf "$asset" pkg/Applications/Emacs
 
             if ! gh release view "$BITRISE_GIT_TAG" --repo hiroakit/emacs-on-apple >/dev/null 2>&1; then
                 gh release create "$BITRISE_GIT_TAG" \
@@ -276,7 +281,7 @@ workflows:
             fi
 
             gh release upload "$BITRISE_GIT_TAG" \
-                "pkg.tar.xz#emacs-${BITRISE_GIT_TAG}-macos.tar.xz" \
+                "$asset" \
                 --repo hiroakit/emacs-on-apple \
                 --clobber
     - slack@3:


### PR DESCRIPTION
## Summary
- The `v30.2-test-release-workflow` test release ended up with an asset whose real filename is `pkg.tar.xz` (see `browser_download_url`), even though the intended name `emacs-v30.2-test-release-workflow-macos.tar.xz` did show up -- as a cosmetic `label`, not the actual name.
- `gh release upload <tag> local-path#label` only sets that display label; the asset's real name/download URL is always the local file's basename. Verified via `gh api repos/.../releases/tags/<tag> --jq '.assets[] | {name, label}'`.
- Fix: rename the tarball to `emacs-${BITRISE_GIT_TAG}-macos.tar.xz` before calling `tar`/`gh release upload`, so the real asset name is correct instead of relying on the label syntax.

## Test plan
- [x] Re-run `release` against a test tag, confirm the published asset's actual filename (not just its label) is `emacs-<tag>-macos.tar.xz` (confirmed via `gh api .../releases/tags/<tag>`: real `name` field was `emacs-v30.2-test-release-workflow-macos.tar.xz`, not just the label)
