### PR TITLE
Point the local build check at emacs30

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ should look closely.
 Confirm the build passes on macOS before opening a PR.
 
 ```sh
-sh build.sh emacs26
+sh build.sh emacs30
 ```
 
 When adding or changing a patch, confirm that it applies cleanly and that


### PR DESCRIPTION
build.sh no longer has an emacs26 target -- build_emacs26() and the
emacs26 command were removed during Phase 0, leaving emacs30 as the only
target. The contributor instructions still told people to run the command
that no longer exists.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EBSrssb9r4ZGxxMGwpebkk