### PR TITLE
Stop force-reinstalling already-present brew packages

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -52,6 +52,14 @@ workflows:
     - brew-install@1.0:
         inputs:
         - packages: autoconf automake pkg-config gnutls texinfo python@3.13 xz
+        # Default `upgrade: yes` makes this step run `brew reinstall`,
+        # force-repouring every package on every build even though the
+        # Bitrise macOS stack already ships all of these preinstalled
+        # (confirmed via the "Outdated Formulae" list in the brew update
+        # step's own output). That cost ~2.4 min/build. `upgrade: no`
+        # switches to `brew install`, which is a near-instant no-op for
+        # anything already present.
+        - upgrade: 'no'
     - script@1:
         title: build.sh
         inputs:
@@ -184,6 +192,8 @@ workflows:
     - brew-install@0:
         inputs:
         - packages: autoconf automake pkg-config gnutls texinfo python xz gh
+        # See the same input on the primary workflow's brew-install step.
+        - upgrade: 'no'
     - script@1:
         title: Build Emacs.app
         inputs:


### PR DESCRIPTION
## Summary
- The `brew-install` Bitrise step's `upgrade` input defaults to `"yes"`, which makes it always run `brew reinstall` instead of `brew install`.
- All packages we list are already preinstalled on the Bitrise macOS stack (confirmed via the "Outdated Formulae" list the preceding `brew update` step prints), so every build was force-repouring bottles that were already there for no reason.
- Measured impact: `Brew install` was 2.4 min (~23%) of a ~10.4 min `primary` build -- the second-largest chunk after `build.sh` itself (7.1 min, ~68%).
- Set `upgrade: 'no'` on both `brew-install` steps (`primary` and `release`). This switches it to plain `brew install`, which for an already-installed, up-to-date formula is a near-instant no-op (verified locally: `brew install autoconf` on an up-to-date install returned in ~7s).

## Test plan
- [ ] Push and confirm the `primary` workflow build still succeeds
- [ ] Compare the `Brew install` step's duration before/after in the Bitrise build log