### PR TITLE
TEST: probe Restore Cache availability (do not merge)

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -36,6 +36,9 @@ workflows:
     - git-clone@8.5:
         inputs:
         - submodule_update_depth: '1'
+    - restore-cache@2:
+        inputs:
+        - key: test-cache-plan-check
     - script@1:
         inputs:
         - content: |-


### PR DESCRIPTION
Quick probe to check whether `restore-cache@2` works on this Bitrise plan (Hobby/free), placed as an early step so it fails fast if blocked. Not intended to be merged -- will close this PR once we have the answer.