### PR TITLE
Cache ccache across builds to speed up build.sh

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -36,6 +36,22 @@ workflows:
     - git-clone@8.5:
         inputs:
         - submodule_update_depth: '1'
+    - restore-cache@2:
+        inputs:
+        # `build.sh` compiles Emacs from scratch every run (see clean() /
+        # build_emacs30() -- no incremental build is possible since the
+        # source itself is re-downloaded each time), which is the single
+        # biggest cost in this workflow (~7 min, ~68% of total). ccache
+        # can't help within a single from-scratch build, but nightly runs
+        # recompile the *same* source+patches+flags repeatedly, so a
+        # cache that persists across builds turns most of that into
+        # cache hits. Confirmed key-based caching (Save/Restore Cache) is
+        # not blocked on the free/Hobby plan (unlike the Pro-only
+        # "Bitrise Build Cache" product for Bazel/Gradle/Xcode, which is
+        # a different, unrelated feature).
+        - key: |-
+            ccache-primary-{{ checksum "build.sh" }}
+            ccache-primary-
     - script@1:
         inputs:
         - content: |-
@@ -51,7 +67,8 @@ workflows:
         title: brew update
     - brew-install@1.0:
         inputs:
-        - packages: autoconf automake pkg-config gnutls texinfo python@3.13 xz
+        - packages: autoconf automake pkg-config gnutls texinfo python@3.13 xz ccache
+        - upgrade: 'no'
     - script@1:
         title: build.sh
         inputs:
@@ -62,7 +79,19 @@ workflows:
             # debug log
             set -x
 
+            # build.sh honors $CC if set, defaulting to plain clang
+            # otherwise, so this doesn't affect anyone building locally
+            # without ccache installed.
+            export CC="ccache clang"
+            export CCACHE_DIR="$HOME/.ccache"
+
             bash build.sh emacs30
+
+            ccache -s
+    - save-cache@1:
+        inputs:
+        - key: ccache-primary-{{ checksum "build.sh" }}
+        - paths: "$HOME/.ccache"
     - script@1:
         title: 'Smoke test: launch built Emacs'
         inputs:
@@ -168,6 +197,14 @@ workflows:
             xcodebuild -version
         title: Echo xcodebuild version
     - git-clone@4: {}
+    - restore-cache@2:
+        inputs:
+        # See the same step in the primary workflow for why this exists.
+        # Separate key prefix so primary/release don't share (and
+        # potentially thrash) the same ccache contents.
+        - key: |-
+            ccache-release-{{ checksum "build.sh" }}
+            ccache-release-
     - script@1:
         inputs:
         - content: |-
@@ -183,7 +220,8 @@ workflows:
         title: brew update
     - brew-install@0:
         inputs:
-        - packages: autoconf automake pkg-config gnutls texinfo python xz gh
+        - packages: autoconf automake pkg-config gnutls texinfo python xz gh ccache
+        - upgrade: 'no'
     - script@1:
         title: Build Emacs.app
         inputs:
@@ -194,7 +232,16 @@ workflows:
             # debug log
             set -x
 
+            export CC="ccache clang"
+            export CCACHE_DIR="$HOME/.ccache"
+
             bash build.sh emacs30
+
+            ccache -s
+    - save-cache@1:
+        inputs:
+        - key: ccache-release-{{ checksum "build.sh" }}
+        - paths: "$HOME/.ccache"
     - script@1:
         title: 'Smoke test: launch built Emacs'
         inputs:

--- a/build.sh
+++ b/build.sh
@@ -129,7 +129,7 @@ build_emacs30() {
     # Reason: https://github.com/hiroakit/emacs-on-apple/issues/2
     # Carried over unverified for v30.2; re-check on real hardware before
     # dropping. See docs/roadmap.md Phase 0 (0-C).
-    ./configure CC=clang\
+    ./configure CC="${CC:-clang}"\
                 --with-ns\
                 --with-modules\
                 --without-x\


### PR DESCRIPTION
## Summary
- \`build.sh\` compiles Emacs from scratch every run (no incremental build possible within one run). That step alone measured ~7 min (~68%) of a ~10.4 min \`primary\` build -- the dominant cost, dwarfing \`Brew install\` (~2.3-2.4 min, ~23%).
- ccache can't help within a single from-scratch build, but nightly/release runs recompile the *same* source+patches+flags repeatedly. Persisting the ccache directory across builds via Bitrise's key-based Save Cache / Restore Cache steps turns most of that repeat work into cache hits.
- Confirmed key-based caching works on the free/Hobby plan (live probe via \`restore-cache\`, see closed throwaway PR #21) -- it's unrelated to the Pro-only "Bitrise Build Cache" product for Bazel/Gradle/Xcode that shows up on the pricing page.

## Changes
- \`build.sh\`: \`CC="${CC:-clang}"\` instead of a hardcoded \`CC=clang\`, so CI can set \`CC="ccache clang"\` while local builds without ccache installed are unaffected. Verified locally under bash (the actual interpreter build.sh uses) that a repeat compile with \`CC="ccache clang"\` hits cache (0.232s cold vs 0.009s warm, Direct hit 1/1).
- Both workflows: install \`ccache\`, export \`CC\`/\`CCACHE_DIR\` before calling \`build.sh\`, \`restore-cache\` before and \`save-cache\` after, keyed by a checksum of \`build.sh\` (separate key prefixes per workflow so \`primary\`/\`release\` don't share cache contents). \`ccache -s\` printed after the build for hit-rate visibility in the log.
- Folded in the \`upgrade: 'no'\` \`brew-install\` change from #20 (touches the same lines) to avoid a merge conflict -- closing #20 as superseded by this PR.

## Test plan
- [ ] First run (cold cache): confirm it still succeeds, and check \`ccache -s\` shows mostly misses
- [ ] Second run (warm cache): confirm \`restore-cache\` finds a hit, \`ccache -s\` shows a meaningfully higher hit rate, and compare \`build.sh\` step duration against the ~7 min baseline
