### PR TITLE
Skip the Slack step on pull_request-triggered builds

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -176,6 +176,15 @@ workflows:
             cp pkg.tar.xz "$BITRISE_DEPLOY_DIR/emacs-30.2_$(date -u +%Y%m%d_%H%M%S_UTC).tar.xz"
     - deploy-to-bitrise-io@2: {}
     - slack@4:
+        # Bitrise withholds Secrets from pull_request-triggered builds by
+        # default -- and for a public repo like this one, that can't be
+        # opted out of. $slack_webhook_url is only populated on the
+        # push-triggered (master) runs, so this step always failed (safely,
+        # is_skippable) on every PR build with "WebhookURL empty". Skip it
+        # outright on PR builds instead of leaving a permanent red entry
+        # in every PR's CI log. $BITRISE_PULL_REQUEST is only set when a
+        # build was triggered by a pull request.
+        run_if: '{{getenv "BITRISE_PULL_REQUEST" | eq ""}}'
         inputs:
         - webhook_url: "$slack_webhook_url"
     meta:
@@ -332,6 +341,10 @@ workflows:
                 --repo hiroakit/emacs-on-apple \
                 --clobber
     - slack@3:
+        # See the same guard on the primary workflow's slack step. release
+        # isn't wired into pull_request triggers today, but keep this
+        # defensively consistent in case that ever changes.
+        run_if: '{{getenv "BITRISE_PULL_REQUEST" | eq ""}}'
         inputs:
         - webhook_url: "$slack_webhook_url"
 meta:


### PR DESCRIPTION
## Summary
- Root cause of the "Send a Slack message (Failed)" entry seen in PR build logs: Bitrise withholds Secrets from `pull_request`-triggered builds by default, and this can't be opted out of for a public repo. `$slack_webhook_url` is only populated on push-triggered (`master`) runs.
- Confirmed the real Slack notifications ("Build Succeeded!", posted via "incoming-webhook") do come from this exact step -- just from the `master`-branch runs where the secret is available. It's not some separate Bitrise/workspace integration.
- Added `run_if: '{{getenv "BITRISE_PULL_REQUEST" | eq ""}}'` to both `slack` steps so they're skipped outright on PR builds instead of always failing (safely, but noisy) with "WebhookURL empty".

## Test plan
- [x] Open a PR and confirm the Slack step is skipped (not failed) in the log (confirmed: `slack@4 (Skipped)` in this PR's own build log)
- [x] Merge to `master` and confirm the Slack step still runs and posts successfully (confirmed: `Send a Slack message` succeeded in the post-merge build log)
