### PR TITLE
Remove unused python from brew-install

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -67,7 +67,7 @@ workflows:
         title: brew update
     - brew-install@1.0:
         inputs:
-        - packages: autoconf automake pkg-config gnutls texinfo python@3.13 xz ccache
+        - packages: autoconf automake pkg-config gnutls texinfo xz ccache
         - upgrade: 'no'
     - script@1:
         title: build.sh
@@ -229,7 +229,7 @@ workflows:
         title: brew update
     - brew-install@0:
         inputs:
-        - packages: autoconf automake pkg-config gnutls texinfo python xz gh ccache
+        - packages: autoconf automake pkg-config gnutls texinfo xz gh ccache
         - upgrade: 'no'
     - script@1:
         title: Build Emacs.app


### PR DESCRIPTION
## Summary
- Emacs 30.2's build has no Python dependency: `configure.ac` has zero python references, and the only hit anywhere in the source tree (`admin/grammars/Makefile.in`'s `python-wy.el`) is a Semantic/CEDET grammar data filename, unrelated to needing the interpreter. No repo script uses it either.
- `bitrise.yml` was originally committed verbatim as exported from a manually-configured Bitrise dashboard (#10), so this was likely never a real requirement -- just carried over.
- Confirmed none of the other listed packages (autoconf, automake, pkg-config, gnutls, texinfo, xz, ccache, gh) depend on it either (`brew deps --tree`).
- Removed `python@3.13` (primary) / `python` (release) from both `brew-install` package lists.

## On timing
- Measured `Brew install` with this change: **7.13 sec**, vs. ~2.2-2.4 min in earlier builds that included python. That gap is too large to attribute to one package -- the same log's per-formula "Installation times" breakdown shows all 17 formulae (gnutls's dependency chain included) actually pour/link in ~1.3 sec combined. Most of `Brew install`'s wall time is bottle-download/network variance on Bitrise's shared infrastructure, not package count.
- This removal is correct on its own merits (unused dependency), just not expected to reliably shave minutes off every build the way the number above might suggest.

## Test plan
- [x] CI passed on this branch (confirmed: `ci/bitrise/6ab4eec93dedce2f/pr` success)