### PR TITLE
Add Info.plist lifecycle keys for macOS app packaging (Phase 1)

### DIFF
--- a/05-info-plist-lifecycle.patch
+++ b/05-info-plist-lifecycle.patch
@@ -1,0 +1,18 @@
+--- a/nextstep/templates/Info.plist.in
++++ b/nextstep/templates/Info.plist.in
+@@ -693,5 +693,15 @@
+         <string>Emacs requires permission to access the Downloads folder.</string>
+         <key>NSRemovableVolumesUsageDescription</key>
+         <string>Emacs requires permission to access files on Removable Volumes.</string>
++	<key>LSMinimumSystemVersion</key>
++	<string>15.0</string>
++	<key>NSHighResolutionCapable</key>
++	<true/>
++	<key>NSSupportsSuddenTermination</key>
++	<false/>
++	<key>NSSupportsAutomaticTermination</key>
++	<false/>
++	<key>NSSupportsAutomaticGraphicsSwitching</key>
++	<true/>
+ </dict>
+ </plist>

--- a/build.sh
+++ b/build.sh
@@ -121,6 +121,7 @@ build_emacs30() {
     patch -p1 -i ../../00-bump-copyright-year.patch
     patch -p1 -i ../../01-remove-blessmail.patch
     patch -p1 -i ../../03-bump-emacs-version.patch
+    patch -p1 -i ../../05-info-plist-lifecycle.patch
     patch -p1 -i ../ns-inline-patch/emacs-29.1-inline.patch
 
     ./autogen.sh

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -238,12 +238,24 @@ README の Usage / Supporting セクションも更新済み。
 
 | キー | 値 | 理由 |
 | --- | --- | --- |
-| `LSMinimumSystemVersion` | 決定した最小 macOS | 未指定だと古い OS で起動して落ちる |
+| `LSMinimumSystemVersion` | `15.0` (Sequoia) | 未指定だと古い OS で起動して落ちる。README の「Supporting: macOS Sequoia」に厳密に合わせ、実機検証済みの OS のみを保証する最も安全な選択とした |
 | `NSHighResolutionCapable` | `true` | Retina 対応の明示 |
 | `NSSupportsSuddenTermination` | `false` | 未保存バッファがある以上、明示的に無効化する。既定も `false` だが意図を残す |
 | `NSSupportsAutomaticTermination` | `false` | 同上 |
 | `NSSupportsAutomaticGraphicsSwitching` | `true` | dGPU 搭載機での電力 |
-| `CFBundleVersion` | ビルド番号 | 現在 `9.0` 固定。配布・notarization で問題になる |
+
+**`CFBundleVersion` はこの表から除外した**: 当初 Phase 1 の対象として挙げていたが、
+`05-info-plist-lifecycle.patch` を実タグボールに適用検証する過程で、
+既存の `03-bump-emacs-version.patch` (由来: 別セッションのコミット
+`ad16df0f4d1 Enabled to change CFBundleVersion dynamically in configure.ac`)
+が既に `<string>9.0</string>` → `<string>@build_number@</string>` と書き換え、
+`configure.ac` 側の `AC_SUBST([build_number], [1])` と組み合わせてビルド番号化
+していることが判明したため。コメント `<!-- This SHOULD be a build number. -->`
+が示す通り `CFBundleVersion` は `CFBundleShortVersionString` (マーケティング
+バージョン、`@version@` = "30.2") とは別物で、両者を混同しない。
+実ビルドでの検証値は `CFBundleVersion` = `"1"`、`CFBundleShortVersionString` =
+`"30.2"` (`plutil -p` で確認、2026-08-05)。値が常に固定 `1` である
+(ビルドのたびに増加しない) 点は Phase 1 のスコープ外の既存事項として残す。
 
 **Phase 1 では追加しないもの** (Phase 4 に回す):
 `LSApplicationCategoryType`、`NSUserActivityTypes` (Handoff)、
@@ -261,10 +273,22 @@ Phase 2 の `application:openURLs:` 実装と**対で入れる**こと。
 
 ### 1-D. 完了条件
 
-- [ ] ビルド後の `Emacs.app/Contents/Info.plist` に上記キーが入っている
-      (`plutil -p pkg/Applications/Emacs/Emacs.app/Contents/Info.plist` で確認)
-- [ ] `.app` が起動する
-- [ ] `codesign` と notarization が従来どおり通る
+- [x] ビルド後の `Emacs.app/Contents/Info.plist` に上記キーが入っている
+      (2026-08-05、macOS Sequoia 実機で `sh build.sh emacs30` を最後まで実行し
+      `plutil -p pkg/Applications/Emacs/Emacs.app/Contents/Info.plist` で確認。
+      `LSMinimumSystemVersion => "15.0"`、`NSHighResolutionCapable => 1`、
+      `NSSupportsSuddenTermination => 0`、`NSSupportsAutomaticTermination => 0`、
+      `NSSupportsAutomaticGraphicsSwitching => 1` をすべて確認)
+- [x] `.app` が起動する (2026-08-05。`--batch --eval` での `emacs-version`/
+      `mac-ime-toggle` チェックに加え、`open` での実 GUI 起動・プロセス確認・
+      終了まで実施)
+- [x] `codesign` と notarization が従来どおり通る (2026-08-05。
+      `codesign --force --deep --sign -` (アドホック、Bitrise CI と同じ手順) で
+      `valid on disk` / `satisfies its Designated Requirement` を確認。
+      `Info.plist entries` はキー追加前の 23 から 28 に増加しており、
+      新規キーがシール対象に含まれていることも確認済み。notarization
+      (Apple 提出) 自体は Phase 0 と同様に未実施 — 無料のアドホック署名運用の
+      ため対象外)
 
 ---
 


### PR DESCRIPTION
## Summary
- Phase 1 (docs/roadmap.md): add `05-info-plist-lifecycle.patch` giving `Emacs.app` the standard macOS lifecycle keys it was missing — `LSMinimumSystemVersion` (15.0, matches README's "Supporting: macOS Sequoia"), `NSHighResolutionCapable`, `NSSupportsSuddenTermination`, `NSSupportsAutomaticTermination`, `NSSupportsAutomaticGraphicsSwitching`.
- `CFBundleVersion` was deliberately left out of this patch: `03-bump-emacs-version.patch` already turns it into a real build-number placeholder (`@build_number@`, distinct from `CFBundleShortVersionString`/`@version@` = "30.2") from an earlier commit — no need to touch it here, and doing so would conflate build number with marketing version.
- No C code touched; the change is purely a `build.sh` patch addition, per Phase 1's stated scope.

## Test plan
- [x] Patch applies cleanly against the pinned official `emacs-30.2.tar.xz` (sha256-verified) with the existing `00`/`01`/`03` patches applied first, in the same order `build.sh` uses.
- [x] `plutil -lint` passes on the patched `Info.plist.in` template.
- [x] Full `sh build.sh emacs30` run on real hardware (macOS Sequoia); `plutil -p` on the built `Emacs.app/Contents/Info.plist` confirms all 5 new keys with correct values (`LSMinimumSystemVersion => "15.0"`, `NSHighResolutionCapable => 1`, `NSSupportsSuddenTermination => 0`, `NSSupportsAutomaticTermination => 0`, `NSSupportsAutomaticGraphicsSwitching => 1`), and `CFBundleVersion => "1"` / `CFBundleShortVersionString => "30.2"` stay correctly distinct.
- [x] Built `.app` launches: verified via `--batch --eval` (`emacs-version` prefix check + `mac-ime-toggle` bound) and via a real `open`-triggered GUI launch (process observed running, then quit cleanly).
- [x] Ad-hoc `codesign --force --deep --sign -` (same as CI) still validates: `valid on disk`, `satisfies its Designated Requirement`; `Info.plist entries` count rose from 23 to 28, confirming the new keys are included in the seal.
- [ ] Bitrise CI (`primary`/`release`) green on this branch — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)