### PR TITLE
Cache the Emacs source archive between builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 src
 pkg
+.cache/
 .bitrise.secrets.yml

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Emacs for Apple devices.
 sh build.sh emacs30
 ```
 
+The verified Emacs source archive is cached in `.cache/downloads/` and reused
+across builds. The `clean` command removes `src/` and `pkg/`, but keeps this
+download cache. Remove `.cache/` when you need to force a fresh download.
+
 # Objective
 
 Immediate

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -38,20 +38,22 @@ workflows:
         - submodule_update_depth: '1'
     - restore-cache@2:
         inputs:
-        # `build.sh` compiles Emacs from scratch every run (see clean() /
-        # build_emacs30() -- no incremental build is possible since the
-        # source itself is re-downloaded each time), which is the single
-        # biggest cost in this workflow (~7 min, ~68% of total). ccache
-        # can't help within a single from-scratch build, but nightly runs
-        # recompile the *same* source+patches+flags repeatedly, so a
-        # cache that persists across builds turns most of that into
-        # cache hits. Confirmed key-based caching (Save/Restore Cache) is
-        # not blocked on the free/Hobby plan (unlike the Pro-only
-        # "Bitrise Build Cache" product for Bazel/Gradle/Xcode, which is
-        # a different, unrelated feature).
+        # `build.sh` compiles Emacs from scratch every run, which is the
+        # single biggest cost in this workflow (~7 min, ~68% of total).
+        # ccache persists compiler outputs, while .cache/downloads persists
+        # the verified Emacs source archive so it is not downloaded again.
+        # Confirmed key-based caching (Save/Restore Cache) is not blocked on
+        # the free/Hobby plan (unlike the Pro-only "Bitrise Build Cache"
+        # product for Bazel/Gradle/Xcode, which is unrelated).
         - key: |-
             ccache-primary-{{ checksum "build.sh" }}
             ccache-primary-
+    # The version and digest make the source archive immutable and allow it
+    # to survive unrelated build.sh changes. build.sh verifies the digest
+    # again before extracting the restored archive.
+    - restore-cache@2:
+        inputs:
+        - key: emacs-source-30.2-b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9
     - script@1:
         inputs:
         - content: |-
@@ -92,6 +94,11 @@ workflows:
         inputs:
         - key: ccache-primary-{{ checksum "build.sh" }}
         - paths: "$HOME/.ccache"
+    - save-cache@1:
+        inputs:
+        - key: emacs-source-30.2-b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9
+        - paths: .cache/downloads
+        - is_key_unique: 'true'
     - script@1:
         title: 'Smoke test: launch built Emacs'
         inputs:
@@ -214,6 +221,9 @@ workflows:
         - key: |-
             ccache-release-{{ checksum "build.sh" }}
             ccache-release-
+    - restore-cache@2:
+        inputs:
+        - key: emacs-source-30.2-b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9
     - script@1:
         inputs:
         - content: |-
@@ -251,6 +261,11 @@ workflows:
         inputs:
         - key: ccache-release-{{ checksum "build.sh" }}
         - paths: "$HOME/.ccache"
+    - save-cache@1:
+        inputs:
+        - key: emacs-source-30.2-b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9
+        - paths: .cache/downloads
+        - is_key_unique: 'true'
     - script@1:
         title: 'Smoke test: launch built Emacs'
         inputs:

--- a/build.sh
+++ b/build.sh
@@ -84,6 +84,9 @@ build_emacs30() {
     declare pkgver="30.2"
     declare -i pkgrel=1
     declare -r sha256sum="b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9"
+    declare -r archive="${pkgname}-${pkgver}.tar.xz"
+    declare -r cachedir="../.cache/downloads"
+    declare -r cached_archive="${cachedir}/${archive}"
 
     mkdir -p ${srcdir}
     cd ${srcdir}
@@ -91,14 +94,20 @@ build_emacs30() {
     # Use the official tarball, not the emacs-mirror git tree: git checkouts
     # lack a generated `configure` and require autogen.sh, which hurts
     # reproducibility. See docs/roadmap.md Phase 0.
-    curl -LO https://ftp.gnu.org/gnu/emacs/${pkgname}-${pkgver}.tar.xz
+    mkdir -p "${cachedir}"
+    if ! test -f "${cached_archive}"; then
+        curl --fail --location \
+             --output "${cached_archive}.tmp" \
+             "https://ftp.gnu.org/gnu/emacs/${archive}"
+        checksum "${cached_archive}.tmp" "${sha256sum}"
+        mv "${cached_archive}.tmp" "${cached_archive}"
+    fi
     if test -e ns-inline-patch; then
         rm -rf ns-inline-patch
     fi
     git clone --depth 1 https://github.com/takaxp/ns-inline-patch.git
 
-    checksum ${pkgname}-${pkgver}.tar.xz\
-             "${sha256sum}"
+    checksum "${cached_archive}" "${sha256sum}"
     if test $? -ne 0; then
         echo "Unmatch sha256sum"
         exit -1
@@ -116,7 +125,7 @@ build_emacs30() {
         exit -1
     fi
 
-    tar Jxfv ${pkgname}-${pkgver}.tar.xz
+    tar Jxfv "${cached_archive}"
     cd ${pkgname}-${pkgver}
     patch -p1 -i ../../00-bump-copyright-year.patch
     patch -p1 -i ../../01-remove-blessmail.patch


### PR DESCRIPTION
## Summary

- cache the verified Emacs 30.2 source archive under `.cache/downloads/`
- preserve the local download cache when `src/` and `pkg/` are cleaned
- restore and save `.cache/downloads` with Bitrise Dependency Cache in both primary and release workflows
- use a source-specific cache key containing the Emacs version and SHA-256
- verify downloads and restored archives before extraction
- document how to force a fresh local download

## Why

`build.sh emacs30` previously downloaded the same Emacs archive whenever the workspace did not retain generated files. Keeping the immutable archive outside `src/` avoids repeated local downloads, and persisting that directory with Bitrise's existing Dependency Cache avoids downloading it on every clean CI machine.

The source archive uses a separate cache entry from ccache. This prevents unrelated `build.sh` changes from invalidating the download and avoids including the 53 MB tarball in every compiler-cache update.

## Impact

The first build for this source key downloads and verifies the official archive. Later local and Bitrise builds reuse it and verify its SHA-256 again before extraction. The compiler cache behavior is unchanged.

## Verification

- parsed `bitrise.yml` successfully with Ruby/Psych
- `bash -n build.sh`
- `git diff --check`
- verified the cached archive SHA-256
- confirmed the local cached archive is 53 MB

The full local build was not run because it begins by deleting existing local `src/` and `pkg/` artifacts.
