### PR TITLE
Centralize Emacs source configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ sh build.sh emacs30
 The verified Emacs source archive is cached in `.cache/downloads/` and reused
 across builds. The `clean` command removes `src/` and `pkg/`, but keeps this
 download cache. Remove `.cache/` when you need to force a fresh download.
+The source version and SHA-256 are pinned in `emacs-source.lock`; update that
+file to select a different Emacs source. Bitrise derives its download-cache
+key from the lockfile automatically.
 
 # Objective
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -53,7 +53,7 @@ workflows:
     # again before extracting the restored archive.
     - restore-cache@2:
         inputs:
-        - key: emacs-source-30.2-b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9
+        - key: emacs-source-{{ checksum "emacs-source.lock" }}
     - script@1:
         inputs:
         - content: |-
@@ -96,7 +96,7 @@ workflows:
         - paths: "$HOME/.ccache"
     - save-cache@1:
         inputs:
-        - key: emacs-source-30.2-b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9
+        - key: emacs-source-{{ checksum "emacs-source.lock" }}
         - paths: .cache/downloads
         - is_key_unique: 'true'
     - script@1:
@@ -119,12 +119,13 @@ workflows:
             # on the *downloaded* copy, not the binary's own correctness.
             bin="pkg/Applications/Emacs/Emacs.app/Contents/MacOS/Emacs"
             test -x "$bin"
+            source emacs-source.lock
 
             # NOTE: --eval reads only the first top-level form from the
             # string, so everything must be wrapped in one (progn ...).
             "$bin" --batch --eval "
             (progn
-              (unless (string-prefix-p \"30.2\" emacs-version)
+              (unless (string-prefix-p \"${EMACS_VERSION}\" emacs-version)
                 (error \"unexpected emacs-version: %s\" emacs-version))
               (unless (fboundp 'mac-ime-toggle)
                 (error \"mac-ime-toggle not bound -- did the ns-inline-patch apply?\"))
@@ -180,7 +181,8 @@ workflows:
             # is picked up by the deploy-to-bitrise-io step below.
             mkdir -p "$BITRISE_DEPLOY_DIR"
             tar cJvf pkg.tar.xz pkg/Applications/Emacs
-            cp pkg.tar.xz "$BITRISE_DEPLOY_DIR/emacs-30.2_$(date -u +%Y%m%d_%H%M%S_UTC).tar.xz"
+            source emacs-source.lock
+            cp pkg.tar.xz "$BITRISE_DEPLOY_DIR/emacs-${EMACS_VERSION}_$(date -u +%Y%m%d_%H%M%S_UTC).tar.xz"
     - deploy-to-bitrise-io@2: {}
     - slack@4:
         # Bitrise withholds Secrets from pull_request-triggered builds by
@@ -223,7 +225,7 @@ workflows:
             ccache-release-
     - restore-cache@2:
         inputs:
-        - key: emacs-source-30.2-b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9
+        - key: emacs-source-{{ checksum "emacs-source.lock" }}
     - script@1:
         inputs:
         - content: |-
@@ -263,7 +265,7 @@ workflows:
         - paths: "$HOME/.ccache"
     - save-cache@1:
         inputs:
-        - key: emacs-source-30.2-b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9
+        - key: emacs-source-{{ checksum "emacs-source.lock" }}
         - paths: .cache/downloads
         - is_key_unique: 'true'
     - script@1:
@@ -280,12 +282,13 @@ workflows:
             # and what it does/doesn't prove.
             bin="pkg/Applications/Emacs/Emacs.app/Contents/MacOS/Emacs"
             test -x "$bin"
+            source emacs-source.lock
 
             # NOTE: --eval reads only the first top-level form from the
             # string, so everything must be wrapped in one (progn ...).
             "$bin" --batch --eval "
             (progn
-              (unless (string-prefix-p \"30.2\" emacs-version)
+              (unless (string-prefix-p \"${EMACS_VERSION}\" emacs-version)
                 (error \"unexpected emacs-version: %s\" emacs-version))
               (unless (fboundp 'mac-ime-toggle)
                 (error \"mac-ime-toggle not bound -- did the ns-inline-patch apply?\"))

--- a/build.sh
+++ b/build.sh
@@ -21,13 +21,20 @@ set -e
 
 declare -r pkgdir="pkg"
 declare -r srcdir="src"
+declare -r BASE_PATH="$(cd "$(dirname "$0")" && pwd)"
+
+# Keep the source version and checksum in one file. Bitrise also hashes this
+# file for its download-cache key, so changing either value invalidates the
+# cached archive automatically.
+source "${BASE_PATH}/emacs-source.lock"
+readonly EMACS_VERSION EMACS_SHA256
 
 # Show usage.
 help() {
 cat <<EOF
 Help: sh $0 command
 command:
-  emacs30: Build Emacs v30 (v30.2)
+  emacs30: Build Emacs v30 (v${EMACS_VERSION})
   clean:   Remove pkgdir, srcdir
 EOF
 }
@@ -51,7 +58,7 @@ checksum() {
     declare -r sha256sum=${2}
     if test ${filesum} != ${sha256sum}; then
         echo "Unmatch sha256sum"
-        exit -1
+        return 1
     fi
 }         
 
@@ -76,14 +83,14 @@ codesign() {
                    ./pkg/Applications/Emacs/Emacs.app
 }
 
-# Build Emacs 30 (v30.2)
+# Build Emacs 30
 build_emacs30() {
     echo "Run ${FUNCNAME[0]}"
 
     declare -r pkgname="emacs"
-    declare pkgver="30.2"
+    declare -r pkgver="${EMACS_VERSION}"
     declare -i pkgrel=1
-    declare -r sha256sum="b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9"
+    declare -r sha256sum="${EMACS_SHA256}"
     declare -r archive="${pkgname}-${pkgver}.tar.xz"
     declare -r cachedir="../.cache/downloads"
     declare -r cached_archive="${cachedir}/${archive}"
@@ -95,6 +102,11 @@ build_emacs30() {
     # lack a generated `configure` and require autogen.sh, which hurts
     # reproducibility. See docs/roadmap.md Phase 0.
     mkdir -p "${cachedir}"
+    if test -f "${cached_archive}" && \
+       ! checksum "${cached_archive}" "${sha256sum}"; then
+        echo "Discard cached archive with unexpected sha256sum"
+        rm -f "${cached_archive}"
+    fi
     if ! test -f "${cached_archive}"; then
         curl --fail --location \
              --output "${cached_archive}.tmp" \
@@ -161,7 +173,6 @@ build_emacs30() {
 }
 
 COMMAND="$1"                 # Using 1st argument as command
-BASE_PATH="$(dirname "$0")"  # Calling script location
 
 case "$COMMAND" in
     "help")

--- a/emacs-source.lock
+++ b/emacs-source.lock
@@ -1,0 +1,3 @@
+# Pinned GNU Emacs source used by build.sh and Bitrise.
+EMACS_VERSION=30.2
+EMACS_SHA256=b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9


### PR DESCRIPTION
## Summary

- add `emacs-source.lock` as the single source of truth for the Emacs version and source SHA-256
- make `build.sh` load its version and checksum from the lockfile
- derive the Bitrise source-cache key from the lockfile checksum
- use the configured version in CI smoke tests and nightly artifact names
- discard and re-download a cached archive when it does not match the configured SHA-256

## Why

The source version and digest were duplicated between `build.sh` and four Bitrise cache entries. Updating only part of that configuration could restore the wrong cache, repeatedly download a new archive without saving it, or fail against an old same-name local archive.

Hashing one lockfile for the Bitrise cache key makes every source configuration change create a new immutable cache entry. Revalidating the local archive makes a same-filename digest change recover automatically.

## Impact

Selecting a different Emacs source now requires changing `emacs-source.lock`. The build, CI cache key, smoke-test expectation, and nightly artifact name then follow that configuration automatically. Existing correctly hashed local archives remain reusable.

## Verification

- `bash -n build.sh`
- `bash build.sh help`
- invoked `build.sh help` from outside the repository to verify lockfile path resolution
- parsed `bitrise.yml` with Ruby/Psych
- parsed every embedded Bitrise shell script with `bash -n`
- verified that the checksum function accepts the pinned archive and rejects an incorrect digest
- `git diff --check`

The full local build was not run because `build.sh emacs30` begins by deleting existing `src/` and `pkg/` artifacts; Bitrise CI will exercise the complete build.
