### PR TITLE
Cancel the Dock reopen handler task

### DIFF
--- a/docs/macos-lifecycle.md
+++ b/docs/macos-lifecycle.md
@@ -119,9 +119,16 @@ Cocoa は `CGDisplayRegisterReconfigurationCallback` (`nsterm.m:5475`) を使う
 
 ### 2.3 未実装のもの (すべて実測で 0 件)
 
+`applicationShouldHandleReopen:hasVisibleWindows:` も未実装だが、対応対象にはしない。
+2026-08-11 の実機検証では、最小化したフレームは reopen Apple Event に対する
+AppKit の標準動作で復帰した。
+Emacs Lisp の `make-frame-invisible` で完全に不可視化したフレームが Dock アイコンの
+クリックで復帰しないのは、明示的な不可視状態を維持する意図的な動作である。
+このメソッドを追加して不可視フレームを自動的に可視化すると、呼び出し側の指定を
+取り消してしまうため、対応タスクを中止した。
+
 | API | 影響 |
 | --- | --- |
-| `applicationShouldHandleReopen:hasVisibleWindows:` | Dock アイコンをクリックしてもフレームが復活しない。体感的な不満として最も大きい |
 | `application:openURLs:` | `application:openFile(s):` は macOS 10.13 で非推奨。URL スキーム (org-protocol 等) を受けられない |
 | `applicationWillTerminate:` | 終了直前の後始末フックがない |
 | `NSWorkspaceWillSleepNotification` / `DidWakeNotification` | スリープ・復帰を検知できない (タイマー、ネットワーク接続の張り直し) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -312,10 +312,19 @@ Phase 2 の `application:openURLs:` 実装と**対で入れる**こと。
 
 ### 着手順 (効果の大きい順)
 
-#### 2-A. `applicationShouldHandleReopen:hasVisibleWindows:`
-Dock アイコンをクリックしてもフレームが復活しない問題。
-**体感的な効果が最も大きいのでここから。** 30.2 に実装は一切ない
-(`Reopen` の出現数 0)。
+#### 2-A. `applicationShouldHandleReopen:hasVisibleWindows:` (対応中止)
+
+30.2 にこのメソッドがないことだけを根拠に、不具合と判断していた。
+2026-08-11 の実機検証では、Dock アイコンのクリックに対応する reopen Apple Event
+だけで、最小化したフレームが AppKit の標準動作によって復帰した。
+
+Emacs Lisp の `make-frame-invisible` で完全に不可視化したフレームは、Dock アイコンを
+クリックしても復帰しない。
+これは明示的に不可視化した状態を維持する意図的な動作であり、Dock からの再選択で
+自動的に可視化すると呼び出し側の指定を取り消してしまう。
+
+したがって、このメソッドは追加しない。
+Phase 2 の実装は 2-B から開始する。
 
 #### 2-B. `applicationShouldTerminate:` の `NSTerminateLater` 化
 **締切問題の本命。** 現状の終了パスには次の問題がある:
@@ -369,7 +378,7 @@ Phase 1 で保留した `CFBundleURLTypes` の追加と**対で行う**。
 
 - [ ] `#ifdef NS_IMPL_COCOA` で囲まれており、GNUstep ビルドを壊さない
 - [ ] 実機で該当イベントを発火させて動作確認済み
-      (スリープ、ログアウト、Dock クリック、ダークモード切替)
+      (スリープ、ログアウト、ダークモード切替)
 - [ ] 上流に出せる粒度でコミットが分かれている (§5)
 
 ---


### PR DESCRIPTION
## Summary

- cancel roadmap item 2-A for `applicationShouldHandleReopen:hasVisibleWindows:`
- document that AppKit already restores a minimized frame on a reopen event
- record that frames hidden explicitly with `make-frame-invisible` intentionally remain hidden
- make Phase 2-B the next implementation task and remove Dock clicking from the common completion checks

## Why

The roadmap inferred a user-visible bug solely from the delegate method being absent. A controlled macOS test showed that a minimized Emacs frame returns through AppKit's standard reopen handling without custom code. Automatically revealing a frame hidden explicitly by Emacs Lisp would instead override the caller's requested state.

## Impact

No Objective-C reopen handler will be added. Phase 2 now starts with termination handling in 2-B, and the lifecycle investigation no longer presents the missing delegate method as a defect.

## Verification

- compared AppKit's standard reopen handling with the previous experimental handler on macOS
- confirmed the minimized frame transition from `icon` back to visible
- confirmed an explicitly invisible frame remains invisible
- `git diff --check`