### PR TITLE
Ignore Codex state and build logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 src
 pkg
 .cache/
+.codex/
+log/
 .bitrise.secrets.yml


### PR DESCRIPTION
## Summary

- ignore the repository-local `.codex/` directory
- ignore the `log/` directory used for local build output

## Why

Both directories contain machine-local state or generated diagnostic output. Keeping them out of Git status prevents accidental inclusion in implementation pull requests.

## Impact

Local Codex environment configuration and build logs no longer appear as untracked files. Existing source and build behavior is unchanged.

## Verification

- `git check-ignore -v .codex/environments/environment.toml log/make_src.log`
- `git diff --check`