### PR TITLE
Add macOS workspace lifecycle notifications

### DIFF
--- a/06-macos-workspace-notifications.patch
+++ b/06-macos-workspace-notifications.patch
@@ -1,0 +1,176 @@
+diff --git a/src/nsterm.h b/src/nsterm.h
+--- a/src/nsterm.h
++++ b/src/nsterm.h
+@@ -797,7 +797,11 @@
+ #define KEY_NS_TOGGLE_TOOLBAR          ((1<<28)|(0<<16)|13)
+ #define KEY_NS_SHOW_PREFS              ((1<<28)|(0<<16)|14)
+ #define KEY_MAC_CHANGE_INPUT_METHOD    ((1<<28)|(0<<16)|15)
+ #define KEY_NS_PUT_MARKED_TEXT         ((1<<28)|(0<<16)|16)
++#define KEY_NS_WILL_SLEEP              ((1<<28)|(0<<16)|17)
++#define KEY_NS_DID_WAKE                ((1<<28)|(0<<16)|18)
++#define KEY_NS_WILL_POWER_OFF          ((1<<28)|(0<<16)|19)
++#define KEY_NS_SESSION_RESIGNED        ((1<<28)|(0<<16)|20)
+ 
+ /* Could use list to store these, but rest of emacs has a big infrastructure
+    for managing a table of bitmap "records".  */
+diff --git a/src/nsterm.m b/src/nsterm.m
+--- a/src/nsterm.m
++++ b/src/nsterm.m
+@@ -6177,5 +6177,25 @@
+ 	   name:NSAntialiasThresholdChangedNotification
+ 	 object:nil];
++
++  NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
++  NSNotificationCenter *workspaceCenter = [workspace notificationCenter];
++  [workspaceCenter addObserver:self
++                      selector:@selector(workspaceWillSleep:)
++                          name:NSWorkspaceWillSleepNotification
++                        object:workspace];
++  [workspaceCenter addObserver:self
++                      selector:@selector(workspaceDidWake:)
++                          name:NSWorkspaceDidWakeNotification
++                        object:workspace];
++  [workspaceCenter addObserver:self
++                      selector:@selector(workspaceWillPowerOff:)
++                          name:NSWorkspaceWillPowerOffNotification
++                        object:workspace];
++  [workspaceCenter
++    addObserver:self
++       selector:@selector(workspaceSessionDidResignActive:)
++           name:NSWorkspaceSessionDidResignActiveNotification
++         object:workspace];
+ #endif
+ 
+ #ifdef NS_IMPL_COCOA
+@@ -6214,6 +6234,47 @@
+ #endif
+ }
+ 
++#ifdef NS_IMPL_COCOA
++static void
++ns_send_workspace_event (int code)
++{
++  struct input_event event;
++  struct frame *frame = SELECTED_FRAME ();
++
++  EVENT_INIT (event);
++
++  event.kind = NS_NONKEY_EVENT;
++  event.code = code;
++  event.arg = Qt;
++  XSETFRAME (event.frame_or_window, frame);
++  kbd_buffer_store_event (&event);
++}
++
++- (void)workspaceWillSleep:(NSNotification *)notification
++{
++  NSTRACE ("[EmacsApp workspaceWillSleep:]");
++  ns_send_workspace_event (KEY_NS_WILL_SLEEP);
++}
++
++- (void)workspaceDidWake:(NSNotification *)notification
++{
++  NSTRACE ("[EmacsApp workspaceDidWake:]");
++  ns_send_workspace_event (KEY_NS_DID_WAKE);
++}
++
++- (void)workspaceWillPowerOff:(NSNotification *)notification
++{
++  NSTRACE ("[EmacsApp workspaceWillPowerOff:]");
++  ns_send_workspace_event (KEY_NS_WILL_POWER_OFF);
++}
++
++- (void)workspaceSessionDidResignActive:(NSNotification *)notification
++{
++  NSTRACE ("[EmacsApp workspaceSessionDidResignActive:]");
++  ns_send_workspace_event (KEY_NS_SESSION_RESIGNED);
++}
++#endif
++
+ 
+ /* Termination sequences:
+     C-x C-c:
+diff --git a/lisp/term/common-win.el b/lisp/term/common-win.el
+--- a/lisp/term/common-win.el
++++ b/lisp/term/common-win.el
+@@ -72,7 +72,11 @@
+ 	       (cons 12 (make-non-key-event 'ns-new-frame))
+ 	       (cons 13 (make-non-key-event 'ns-toggle-toolbar))
+ 	       (cons 14 (make-non-key-event 'ns-show-prefs))
+-	       (cons 15 (make-non-key-event 'mac-change-input-method))))))
++	       (cons 15 (make-non-key-event 'mac-change-input-method))
++	       (cons 17 (make-non-key-event 'ns-workspace-will-sleep))
++	       (cons 18 (make-non-key-event 'ns-workspace-did-wake))
++	       (cons 19 (make-non-key-event 'ns-workspace-will-power-off))
++	       (cons 20 (make-non-key-event 'ns-workspace-session-resigned))))))
+     (set-terminal-parameter frame 'x-setup-function-keys t)))
+ 
+ (defvar x-invocation-args)
+diff --git a/lisp/term/ns-win.el b/lisp/term/ns-win.el
+--- a/lisp/term/ns-win.el
++++ b/lisp/term/ns-win.el
+@@ -167,7 +167,47 @@
+ ;; Allow shift-clicks to work similarly to under Nextstep.
+ (define-key global-map [S-mouse-1] 'mouse-save-then-kill)
+ (global-unset-key [S-down-mouse-1])
++
++(defcustom ns-workspace-will-sleep-hook nil
++  "Hook run when macOS is about to put the system to sleep."
++  :type 'hook
++  :group 'ns)
++
++(defcustom ns-workspace-did-wake-hook nil
++  "Hook run after macOS wakes the system from sleep."
++  :type 'hook
++  :group 'ns)
++
++(defcustom ns-workspace-will-power-off-hook nil
++  "Hook run when macOS requests logout or system power off."
++  :type 'hook
++  :group 'ns)
++
++(defcustom ns-workspace-session-did-resign-active-hook nil
++  "Hook run before the macOS user session switches out."
++  :type 'hook
++  :group 'ns)
++
++(defun ns--run-workspace-will-sleep-hook ()
++  "Run `ns-workspace-will-sleep-hook'."
++  (interactive)
++  (run-hooks 'ns-workspace-will-sleep-hook))
++
++(defun ns--run-workspace-did-wake-hook ()
++  "Run `ns-workspace-did-wake-hook'."
++  (interactive)
++  (run-hooks 'ns-workspace-did-wake-hook))
++
++(defun ns--run-workspace-will-power-off-hook ()
++  "Run `ns-workspace-will-power-off-hook'."
++  (interactive)
++  (run-hooks 'ns-workspace-will-power-off-hook))
++
++(defun ns--run-workspace-session-did-resign-active-hook ()
++  "Run `ns-workspace-session-did-resign-active-hook'."
++  (interactive)
++  (run-hooks 'ns-workspace-session-did-resign-active-hook))
+ 
+ ;; Special Nextstep-generated events are converted to function keys.  Here
+ ;; are the bindings for them.  Note, these keys are actually declared in
+ ;; x-setup-function-keys in common-win.
+@@ -179,8 +219,16 @@
+ (define-key global-map [ns-new-frame] 'make-frame)
+ (define-key global-map [ns-toggle-toolbar] 'ns-toggle-toolbar)
+ (define-key global-map [ns-show-prefs] 'customize)
+ (define-key global-map [mac-change-input-method] 'mac-change-input-method)
++(define-key global-map [ns-workspace-will-sleep]
++            #'ns--run-workspace-will-sleep-hook)
++(define-key global-map [ns-workspace-did-wake]
++            #'ns--run-workspace-did-wake-hook)
++(define-key global-map [ns-workspace-will-power-off]
++            #'ns--run-workspace-will-power-off-hook)
++(define-key global-map [ns-workspace-session-resigned]
++            #'ns--run-workspace-session-did-resign-active-hook)
+ 
+ ;; Set up a number of aliases and other layers to pretend we're using
+ ;; the Choi/Mitsuharu Carbon port.
+ 

--- a/build.sh
+++ b/build.sh
@@ -144,6 +144,7 @@ build_emacs30() {
     patch -p1 -i ../../03-bump-emacs-version.patch
     patch -p1 -i ../../05-info-plist-lifecycle.patch
     patch -p1 -i ../ns-inline-patch/emacs-29.1-inline.patch
+    patch -p1 -i ../../06-macos-workspace-notifications.patch
 
     ./autogen.sh
 

--- a/docs/ns-workspace-lifecycle-test.org
+++ b/docs/ns-workspace-lifecycle-test.org
@@ -1,0 +1,96 @@
+#+title: NSWorkspaceライフサイクル通知の実機テスト
+
+* 目的
+
+macOSが発行するスリープ、復帰、ファストユーザスイッチ、ログアウトの通知が、Emacs Lispのhookまで届くことを確認する。
+テスト用Emacsは =-Q= で起動し、受信した通知を =~/Library/Logs/EmacsWorkspaceLifecycle.log= へ即時追記する。
+
+* 準備
+
+未保存の作業を保存する。
+ファストユーザスイッチには別のローカルユーザーが必要になる。
+ログアウトはCodexやTerminalの接続を終了させる可能性があるため、最後に実施する。
+
+リポジトリのルートで、検証対象のアプリとスクリプトを指定する。
+=TEST_APP= には =06-macos-workspace-notifications.patch= を含むビルドを指定する。
+
+#+begin_src sh
+TEST_APP="$PWD/pkg/Applications/Emacs/Emacs.app"
+TEST_SCRIPT="$PWD/test/manual/ns-workspace-lifecycle.el"
+
+sw_vers
+"$TEST_APP/Contents/MacOS/Emacs" --batch -Q \
+  --eval '(princ (format "Emacs %s / %s\n" emacs-version system-configuration))'
+
+open -na "$TEST_APP" --args -Q -l "$TEST_SCRIPT"
+tail -n 5 ~/Library/Logs/EmacsWorkspaceLifecycle.log
+#+end_src
+
+=Emacs NSWorkspace lifecycle test= というフレームと、次の起動記録を確認する。
+
+#+begin_example
+2026-08-13T00:00:00+0900	test-start	pid=12345	emacs=30.2
+#+end_example
+
+* スリープと復帰
+
+1. Appleメニューから「スリープ」を選ぶ。
+2. Macが完全にスリープしてから10秒程度待つ。
+3. Macを復帰させ、必要ならロックを解除する。
+4. テスト用Emacsのフレームとバッファが残り、操作できることを確認する。
+5. =tail -n 10 ~/Library/Logs/EmacsWorkspaceLifecycle.log= を実行する。
+
+合格条件は、=will-sleep= と =did-wake= がこの順序で記録されることである。
+通知の重複、応答停止、フレームやバッファの消失があれば記録する。
+
+* ファストユーザスイッチ
+
+1. 現在のユーザーからログアウトせず、別のユーザーへ切り替える。
+2. 別ユーザー側で10秒程度待つ。
+3. 元のユーザーへ切り替える。
+4. テスト用Emacsが引き続き操作できることを確認する。
+5. =tail -n 10 ~/Library/Logs/EmacsWorkspaceLifecycle.log= を実行する。
+
+合格条件は、=session-did-resign-active= が記録されることである。
+画面のロックだけではこのテストにならない可能性があるため、別ユーザーのセッションへ切り替える。
+元のユーザーへ戻った際の通知は今回の実装対象ではない。
+
+* ログアウト
+
+1. テスト用Emacsが動作していることを確認する。
+2. Appleメニューから通常の「ログアウト」を選ぶ。
+3. 強制ログアウトは選ばない。
+4. 再ログイン後、=tail -n 15 ~/Library/Logs/EmacsWorkspaceLifecycle.log= を実行する。
+
+合格条件は、Emacsが終了する前に =will-power-off= が記録されることである。
+ログアウト確認画面やアプリ終了待ちが表示された場合は、表示内容と選択したボタンも記録する。
+
+* 結果の記録
+
+各テストについて、macOSのバージョン、Emacsのビルド、実際の操作、操作前後の状態、該当するログ行、合否を記録する。
+全ログは次のコマンドで取得できる。
+
+#+begin_src sh
+cat ~/Library/Logs/EmacsWorkspaceLifecycle.log
+#+end_src
+
+* 2026-08-15の実機結果
+
+macOS 15.7.9（ビルド24G830）、Apple Silicon、Emacs 30.2で実施した。
+
+| 操作 | 記録時刻 | 通知 | 結果 |
+|------+----------+------+------|
+| Appleメニューからスリープし、復帰 | 09:53:16 | =will-sleep= | 合格 |
+| 同上 | 09:54:56 | =did-wake= | 合格 |
+| 画面をロックし、別ユーザーへ切り替え | 09:56:37 | =session-did-resign-active= | 合格 |
+| Appleメニューから通常ログアウト | 10:25:29 | =will-power-off= | 合格 |
+
+スリープとファストユーザスイッチ後は同じEmacsプロセスが動作を続けた。
+元のユーザーへ戻った後、テスト用Emacsの =*scratch*= バッファで日本語を入力できた。
+
+初回のログアウト試験では =will-power-off= が記録されなかった。
+通知を一時的な =emacs_event= へ格納する実装では、ログアウト時の通知を捨てる可能性があった。
+=kbd_buffer_store_event= へ直接格納するよう修正し、再ビルド後のログアウト試験で通知を確認した。
+
+=*scratch*= の内容はログアウト後に復元されなかった。
+=*scratch*= は通常ファイルへ保存されないため、この結果は通知hookの合否には含めない。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -355,6 +355,14 @@ Cmd-Q とログアウトで挙動が食い違う。両方の経路を実機で�
 **購読先は `[NSWorkspace sharedWorkspace] notificationCenter` であって
 `[NSNotificationCenter defaultCenter]` ではない。** 間違えると通知が来ない。
 
+**完了 (2026-08-15)**: 4 通知を Lisp hook に変換するパッチを追加した。
+macOS 15.7.9 (24G830)、Apple Silicon、Emacs 30.2 で、スリープと復帰、
+別ユーザーへのファストユーザスイッチ、通常のログアウトを実施し、
+各通知が記録されることを確認した。
+通知は `emacs_event` の有効期間に依存させず、`kbd_buffer_store_event` へ
+直接格納する。前者ではログアウト通知が失われることを実機で確認したためである。
+再現手順とログは `docs/ns-workspace-lifecycle-test.org` を参照する。
+
 #### 2-D. ダークモードの自動追従
 30.2 は `-[EmacsWindow setAppearance]` (`nsterm.m:9867`) で
 `ns-appearance` フレームパラメータから外観を**設定する**だけで、

--- a/test/manual/ns-workspace-lifecycle.el
+++ b/test/manual/ns-workspace-lifecycle.el
@@ -1,0 +1,37 @@
+;;; ns-workspace-lifecycle.el --- Log macOS workspace notifications -*- lexical-binding: t; -*-
+
+(defconst emacs-workspace-test-log
+  (or (getenv "EMACS_WORKSPACE_TEST_LOG")
+      (expand-file-name "EmacsWorkspaceLifecycle.log" "~/Library/Logs/")))
+
+(dolist (hook '(ns-workspace-will-sleep-hook
+                ns-workspace-did-wake-hook
+                ns-workspace-will-power-off-hook
+                ns-workspace-session-did-resign-active-hook))
+  (unless (boundp hook)
+    (error "This Emacs does not define %s" hook)))
+
+(defun emacs-workspace-test-record (event)
+  (with-temp-buffer
+    (insert (format-time-string "%Y-%m-%dT%H:%M:%S%z")
+            "\t" event
+            "\tpid=" (number-to-string (emacs-pid))
+            "\temacs=" emacs-version
+            "\n")
+    (write-region (point-min) (point-max)
+                  emacs-workspace-test-log 'append 'silent)))
+
+(add-hook 'ns-workspace-will-sleep-hook
+          (apply-partially #'emacs-workspace-test-record "will-sleep"))
+(add-hook 'ns-workspace-did-wake-hook
+          (apply-partially #'emacs-workspace-test-record "did-wake"))
+(add-hook 'ns-workspace-will-power-off-hook
+          (apply-partially #'emacs-workspace-test-record "will-power-off"))
+(add-hook 'ns-workspace-session-did-resign-active-hook
+          (apply-partially #'emacs-workspace-test-record
+                           "session-did-resign-active"))
+
+(emacs-workspace-test-record "test-start")
+(set-frame-name "Emacs NSWorkspace lifecycle test")
+
+;;; ns-workspace-lifecycle.el ends here


### PR DESCRIPTION
## Summary

- subscribe to macOS workspace sleep, wake, power-off, and session-deactivation notifications
- expose those notifications as Emacs Lisp hooks
- enqueue lifecycle events directly with `kbd_buffer_store_event` so logout notifications are not lost
- add the patch to the build, plus a reusable manual test script and test procedure
- mark roadmap task 2-C complete

## Why

Emacs 30.2 does not expose these `NSWorkspace` lifecycle notifications to Lisp. The first implementation used the transient `emacs_event`, but actual logout testing showed that the power-off event could be discarded. Directly storing the event in the keyboard buffer makes the notification available before Emacs terminates.

## User impact

Configurations can react to sleep, wake, fast user switching, and logout or power-off through dedicated Lisp hooks. This enables lifecycle-aware cleanup and reconnection logic without polling.

## Validation

Tested on macOS 15.7.9 (24G830), Apple Silicon, with Emacs 30.2:

- actual sleep and wake produced `will-sleep` and `did-wake`
- fast user switching produced `session-did-resign-active`
- actual logout produced `will-power-off`
- the revised patch applied cleanly to a fresh Emacs 30.2 source tree
- `nsterm.o` compiled without warnings
- the manual Lisp test loaded successfully
- shell syntax, Org structure, and whitespace checks passed
- commit `e4229954be2` has a verified GPG signature
