### PR TITLE
Document deferred termination verification

### DIFF
--- a/docs/macos-lifecycle.md
+++ b/docs/macos-lifecycle.md
@@ -66,15 +66,17 @@ Tramp のブロッキング I/O) は一切ポンプしないため、macOS か�
 1. **ポンプ頻度の底上げ** — Emacs の `Vinhibit_quit` / QUIT チェック地点や
    `atimer` から定期的に `ns_read_socket_1(..., YES)` 相当を回す。
    影響範囲は小さいが、根本解決にはならない。
-2. **締切のあるイベントだけ別扱い** — `applicationShouldTerminate:` で
+2. **締切のあるイベントだけ別扱い**：`applicationShouldTerminate:` で
    `NSTerminateLater` を返し、Lisp 側の保存処理完了後に
    `replyToApplicationShouldTerminate:YES` を呼ぶ。
-   AppKit に「待っている」と伝えられるので強制終了を回避できる。**費用対効果が最も高い。**
+   ただし、2026-08-12 の実機試作では AppKit の終了待機ループから Lisp へ制御が戻らず、
+   保存処理を開始できなかった。
+   この方法はランループ改修と組み合わせる必要がある。
 3. **App Nap を明示的に抑止** — `[[NSProcessInfo processInfo]
    beginActivityWithOptions:NSActivityUserInitiated reason:@"..."]`。
    数行で効果が出る。
 
-推奨は 2 → 3 → 1 の順。
+推奨は 3 → 1 → 2 の順。
 
 ---
 
@@ -114,8 +116,11 @@ Cocoa は `CGDisplayRegisterReconfigurationCallback` (`nsterm.m:5475`) を使う
 - **`NSTerminateLater` と `replyToApplicationShouldTerminate:` はどちらも 0 件。**
   ログアウト時に「保存処理をしているので待ってほしい」と AppKit に伝える
   正規の手段を使っていない。
+  ただし、通常の Quit Apple Event は既存の `KEY_NS_POWER_OFF` 経由で正常終了することを
+  2026-08-12 に実機確認した。
 
-→ ここが §1.3 の方針 2 で直すべき箇所。
+この不足は §1.3 の方針 2 だけでは直せない。
+`NSTerminateLater` の待機中に Lisp を実行できるよう、ランループ側の対応が先に必要になる。
 
 ### 2.3 未実装のもの (すべて実測で 0 件)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -324,10 +324,12 @@ Emacs Lisp の `make-frame-invisible` で完全に不可視化したフレーム
 自動的に可視化すると呼び出し側の指定を取り消してしまう。
 
 したがって、このメソッドは追加しない。
-Phase 2 の実装は 2-B から開始する。
+2-B を保留し、Phase 2 の実装は 2-C から開始した。
+2-C は完了しているため、次は 2-D に着手する。
 
-#### 2-B. `applicationShouldTerminate:` の `NSTerminateLater` 化
-**締切問題の本命。** 現状の終了パスには次の問題がある:
+#### 2-B. `applicationShouldTerminate:` の `NSTerminateLater` 化 (Phase 3 まで保留)
+
+現状の終了パスには次の問題がある:
 
 - `-[EmacsApp terminate:]` (`nsterm.m:6248`) が `NSApplication` の
   `terminate:` をオーバーライドし、**`[super terminate:]` を呼ばない**
@@ -338,9 +340,20 @@ Phase 2 の実装は 2-B から開始する。
   どちらも出現数 0** — ログアウト時に「保存中なので待ってほしい」と
   AppKit に伝える正規の手段を使っていない
 
-`applicationShouldTerminate:` で `NSTerminateLater` を返し、
-Lisp 側の保存完了後に `replyToApplicationShouldTerminate:YES` を呼ぶ形にする。
-これでログアウト・シャットダウン時の強制終了を回避できる。
+2026-08-12 に macOS 15.7.9、Emacs 30.2、Apple Silicon の実機で、
+Quit Apple Event を PID 指定で送信して検証した。
+変更前の Emacs は `NSTerminateNow` を返した後、既存の
+`KEY_NS_POWER_OFF` 経由で `save-buffers-kill-emacs` を実行し、正常終了した。
+
+一方、`applicationShouldTerminate:` で `NSTerminateLater` を返し、
+`KEY_NS_POWER_OFF` と `NX_APPDEFINED` を投入する試作では、AppKit の終了待機ループから
+Emacs の Lisp ループへ制御が戻らず、保存処理を開始できなかった。
+`replyToApplicationShouldTerminate:` を呼ぶ Lisp コード自体が実行されないため、
+この方法だけでは終了待ちを完了できない。
+
+したがって、`NSTerminateLater` 化は Phase 2 の独立タスクとして実装しない。
+Phase 3 でランループを改修し、AppKit の終了待機中にも Lisp 処理を進められる構造を
+用意してから再検討する。
 
 **注意**: 2 つの終了パスが重複しているため、片方だけ直すと
 Cmd-Q とログアウトで挙動が食い違う。両方の経路を実機で確認すること。
@@ -391,7 +404,7 @@ Phase 1 で保留した `CFBundleURLTypes` の追加と**対で行う**。
 
 ---
 
-## Phase 3: ランループ — 本丸
+## Phase 3: ランループ
 
 **ここが本質的な問題。Phase 2 まで終えた状態で着手する。**
 
@@ -427,12 +440,14 @@ macOS 10.9 専用の回避策で、現行 macOS では `[super run]` に素通�
                        reason:@"..."];
    ```
    返り値のトークンを保持し続ける必要がある点に注意。
-2. **締切のあるイベントの別扱い** — Phase 2-B の `NSTerminateLater` 化が
-   これに当たる。Phase 2 で済んでいれば大きな山は越えている。
-3. **ポンプ頻度の底上げ** — Emacs の `atimer` などから定期的に
+2. **ポンプ頻度の底上げ**：Emacs の `atimer` などから定期的に
    `ns_read_socket_1(..., YES)` 相当を回す。
-   **影響範囲が広く、根本解決にもならない。最後の手段。**
-   ここに手を出す前に、1 と 2 で実用上十分かを実機で測ること。
+   影響範囲が広いため、AppKit の終了待機ループと Lisp の実行を接続できる
+   最小の変更範囲を先に特定する。
+3. **締切のあるイベントの別扱い**：2 の接続を用いて Phase 2-B の
+   `NSTerminateLater` 化を再試験する。
+   保存の完了とキャンセルの両方で `replyToApplicationShouldTerminate:` が
+   呼ばれることを確認する。
 
 ### 3-C. 完了条件
 


### PR DESCRIPTION
## What changed

- Record the macOS 15.7.9 / Emacs 30.2 Phase 2-B termination experiment.
- Defer `NSTerminateLater` support until the Phase 3 run-loop work.
- Update the roadmap ordering so Phase 2 proceeds to 2-D after the completed 2-C work.

## Why

The prototype returned `NSTerminateLater` and queued `KEY_NS_POWER_OFF` and
`NX_APPDEFINED`, but control did not return from AppKit's termination wait loop
to the Emacs Lisp loop. The Lisp code responsible for saving buffers and
calling `replyToApplicationShouldTerminate:` therefore could not run.

The run loop must first allow Lisp processing during AppKit's termination wait.

## Impact

This is a documentation-only change. It prevents Phase 2 from proceeding with
an independently incomplete termination implementation and records the
dependency for Phase 3.

## Validation

- `git diff --check`
- Confirmed the documented source paths and current `applicationShouldTerminate:` behavior against the Emacs 30.2 source checkout.
- The hardware experiment was performed and recorded on 2026-08-12; it was not repeated for this documentation-only commit.
